### PR TITLE
Fix long path issue in windows

### DIFF
--- a/resources/executables/windows/ballerina.bat
+++ b/resources/executables/windows/ballerina.bat
@@ -53,7 +53,7 @@ FOR %%C in ("%BALLERINA_HOME%\bre\lib\bootstrap\*.jar") DO set BALLERINA_CLASSPA
 
 set BALLERINA_CLASSPATH="%BVM_HOME%\lib\tools.jar";%BALLERINA_CLASSPATH%;
 
-FOR %%D in ("%BALLERINA_HOME%\bre\lib\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\%%~nD%%~xD"
+set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\*"
 
 rem ----- Process the input command -------------------------------------------
 

--- a/resources/executables/windows/composer.bat
+++ b/resources/executables/windows/composer.bat
@@ -128,7 +128,7 @@ rem ----------------- Execute The Requested Command ----------------------------
 cd %BALLERINA_HOME%
 
 FOR %%C in ("%BALLERINA_HOME%\resources\composer\services\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;".\resources\composer\services\%%~nC%%~xC"
-FOR %%D in ("%BALLERINA_HOME%\bre\lib\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\%%~nD%%~xD"
+set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\*"
 rem ---------- Add jars to classpath ----------------
 
 rem set BALLERINA_CLASSPATH=.\bin\bootstrap;%BALLERINA_CLASSPATH%


### PR DESCRIPTION
## Purpose
Fix long path issue in windows.
relates to https://github.com/ballerina-platform/ballerina-lang/issues/7420

## Goals
Fix long path issue in windows when running ballerina or composer.

## Approach
Add all libraries to the ballerina class path using wildcard.