### PR TITLE
Fix windows ballerina runtime issues

### DIFF
--- a/resources/executables/windows/ballerina.bat
+++ b/resources/executables/windows/ballerina.bat
@@ -34,9 +34,6 @@ rem ----- set BALLERINA_HOME ----------------------------
 rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
 set BALLERINA_HOME=%~sdp0..
 set BVM_HOME=%BALLERINA_HOME%\bre\lib\jre1.8.0_172
-SET curDrive=%cd:~0,1%
-SET ballerinaDrive=%BALLERINA_HOME:~0,1%
-if not "%curDrive%" == "%ballerinaDrive%" %ballerinaDrive%:
 
 goto updateClasspath
 

--- a/resources/executables/windows/composer.bat
+++ b/resources/executables/windows/composer.bat
@@ -36,9 +36,6 @@ rem ----- Only set BALLERINA_HOME if not already set ---------------------------
 rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
 set BALLERINA_HOME=%~sdp0..
 set BVM_HOME=%BALLERINA_HOME%\bre\lib\jre1.8.0_172
-SET curDrive=%cd:~0,1%
-SET wsasDrive=%BALLERINA_HOME:~0,1%
-if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem find BALLERINA_HOME if it does not exist due to either an invalid value passed
 rem by the user or the %0 problem on Windows 9x


### PR DESCRIPTION
This commits fixes the issue of ballerina files are not getting executed if they are on a different drive than of BVM.

Related to https://github.com/ballerina-platform/ballerina-lang/issues/8364