### PR TITLE
Mandate java version 1.8 for ballerina runtime

### DIFF
--- a/resources/executables/linux/ballerina
+++ b/resources/executables/linux/ballerina
@@ -149,6 +149,12 @@ if [ "$CMD" = "--java.debug" ]; then
   echo "Please start the remote debugging client to continue..."
 fi
 
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8|9]"`
+if [ "$jdk_18" = "" ]; then
+   echo "Error: Ballerina is supported only on JDK 1.8 and above"
+   exit 1
+fi
+
 BALLERINA_XBOOTCLASSPATH=""
 for f in "$BALLERINA_HOME"/bre/lib/bootstrap/xboot/*.jar
 do

--- a/resources/executables/macos/ballerina
+++ b/resources/executables/macos/ballerina
@@ -149,6 +149,12 @@ if [ "$CMD" = "--java.debug" ]; then
   echo "Please start the remote debugging client to continue..."
 fi
 
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8|9]"`
+if [ "$jdk_18" = "" ]; then
+   echo "Error: Ballerina is supported only on JDK 1.8 and above"
+   exit 1
+fi
+
 BALLERINA_XBOOTCLASSPATH=""
 for f in "$BALLERINA_HOME"/bre/lib/bootstrap/xboot/*.jar
 do

--- a/resources/executables/windows/ballerina.bat
+++ b/resources/executables/windows/ballerina.bat
@@ -85,6 +85,21 @@ goto end
 :doneStart
 if "%OS%"=="Windows_NT" @setlocal
 if "%OS%"=="WINNT" @setlocal
+rem find the version of the jdk
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk18
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8|9]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk18
+
+:unknownJdk
+echo Ballerina is supported only on JDK 1.8 and above
+goto end
+
+:jdk18
 goto runServer
 
 


### PR DESCRIPTION
This will mandate java version 1.8 for ballerina runtime. Related to https://github.com/ballerina-platform/ballerina-lang/issues/3017