### PR TITLE
Fix the issue of depending JAVA_HOME to check java version

### DIFF
--- a/resources/executables/windows/ballerina.bat
+++ b/resources/executables/windows/ballerina.bat
@@ -92,7 +92,7 @@ set CMD=RUN %*
 
 :checkJdk8AndHigher
 set JVER=
-for /f tokens^=2-5^ delims^=.-_^" %%j in ('"%JAVA_HOME%\bin\java" -fullversion 2^>^&1') do set "JVER=%%j%%k"
+for /f tokens^=2-5^ delims^=.-_^" %%j in ('"%BVM_HOME%\bin\java" -fullversion 2^>^&1') do set "JVER=%%j%%k"
 set JAVA_MODULES=
 rem In, JDK9 or above need to import 'java.corba' module
 if %JVER% GEQ 90 set JAVA_MODULES="--add-modules java.corba"


### PR DESCRIPTION
## Purpose
> Fix the issue of depending JAVA_HOME to check java version. Since Ballerina distribution depends on its own JVM; need to check JVM version with the `%BVM_HOME%\bin\java` instead of `%JAVA_HOME%\bin\java`.