### PR TITLE
fixing BALLERINA_HOME inference issue for linux resource, fixes #112

### DIFF
--- a/resources/executables/linux/ballerina
+++ b/resources/executables/linux/ballerina
@@ -32,7 +32,7 @@
 [ -f /etc/profile.d/wso2.sh ] && source /etc/profile.d/wso2.sh
 
 if [[ ( -z "${BALLERINA_HOME}" || ! -d "${BALLERINA_HOME}" ) && -d "/usr/lib64/ballerina" ]]; then
-    export BALLERINA_HOME="/usr/lib64/ballerina/"$(ls -1 /usr/lib64/ballerina/ | grep 'ballerina[0-9\.a-zA-Z]*' | head -1)
+    export BALLERINA_HOME="/usr/lib64/ballerina/"$(ls -1t /usr/lib64/ballerina/ | grep 'ballerina[0-9\.a-zA-Z]*' | head -1)
 fi
 
 JAVA_HOME=$BALLERINA_HOME/bre/lib/jre1.8.0_172

--- a/resources/executables/linux/ballerina
+++ b/resources/executables/linux/ballerina
@@ -30,6 +30,11 @@
 # -----------------------------------------------------------------------------
 
 [ -f /etc/profile.d/wso2.sh ] && source /etc/profile.d/wso2.sh
+
+if [[ ( -z "${BALLERINA_HOME}" || ! -d "${BALLERINA_HOME}" ) && -d "/usr/lib64/ballerina" ]]; then
+    export BALLERINA_HOME="/usr/lib64/ballerina/"$(ls -1 /usr/lib64/ballerina/ | grep 'ballerina[0-9\.a-zA-Z]*' | head -1)
+fi
+
 JAVA_HOME=$BALLERINA_HOME/bre/lib/jre1.8.0_172
 
 # OS specific support.  $var _must_ be set to either true or false.


### PR DESCRIPTION
Signed-off-by: AbhishekKr <abhikumar163@gmail.com>

## Purpose
This fixes reported issue#112.

## Goals
It will allow linux resource to infer BALLERINA_HOME if auto-configured env var is missing or wrong.

## Approach
If auto-configured env var BALLERINA_HOME is missing or wrong, it checks for relevant dir-names under `/usr/lib64/ballerina/` and fixes the value.

## Release note
This fixes BALLERINA_HOME issue causng `Error: JAVA_HOME is not defined correctly.` for linux (at least rpm) release `v0.983.0-1`.

## Documentation
N/A. This is just a fix for already existing flow.

## Certification
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A