### PR TITLE
Fix quoted args getting trimmed by the bash script

### DIFF
--- a/resources/tools/bin/ballerina
+++ b/resources/tools/bin/ballerina
@@ -33,4 +33,4 @@ fi
 BALLERINA_HOME="$CURRENT_PATH/../distributions/$BALLERINA_VERSION"
 
 export BALLERINA_HOME
-$BALLERINA_HOME/bin/./ballerina $@
+$BALLERINA_HOME/bin/./ballerina "$@"


### PR DESCRIPTION
## Purpose
<BAL_CMD> "this is a space"

The above quoted string is parsed as four different string arguments [this, is, a, space]. I think the quotes are getting removed. But this is observed in a Linux environment only, but it is working as expected in a Mac environment, i.e the quoted string is treated as a single argument. The issue was with the bash script proxy file which does not honor the quoted string args.

Resolves https://github.com/ballerina-platform/ballerina-lang/issues/19547
