### PR TITLE
Add ballerina socket stdlib module build configs

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -39,6 +39,11 @@ def ballerinaLinuxDistributionZip = file("$project.buildDir/distributions/baller
 def ballerinaMacDistributionZip = file("$project.buildDir/distributions/ballerina-macos-${ballerinaVersion}.zip")
 def ballerinaWindowsDistributionZip = file("$project.buildDir/distributions/ballerina-windows-${ballerinaVersion}.zip")
 
+// Read StdLib config JSON
+def stdLibInputFile = new File("${project.rootDir}/ballerina/resources/stdlib-configs.json")
+def stdLibConfigs = new JsonSlurper().parseText(stdLibInputFile.text)
+
+
 task unpackBallerinaJre(type: Copy) {
     group = "unpack_dependencies"
     configurations.ballerinaJre.resolvedConfiguration.resolvedArtifacts.each { artifact ->
@@ -103,9 +108,9 @@ task unpackKubernetesExamples(type: Copy) {
     }
 }
 
-task unpackSocketBallerina(type: Copy) {
+task unpackStdLibs(type: Copy) {
     group = "unpack_dependencies"
-    configurations.socketBallerina.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+    configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         from zipTree(artifact.getFile())
         into new File("${buildDir}/target/extracted-distributions", artifact.name+"-zip")
     }
@@ -188,8 +193,17 @@ task packageDist(type: Zip) {
     }
 
     /* Standard Libraries */
-    into("${parentDir}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
+    stdLibConfigs.each { stdLibConfig ->
+        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def breLibSourcePath = stdLibConfig.breLibSourcePath
+        into("${parentDir}/bir-cache/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${parentDir}/bre/lib") {
+            from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
     }
 
     /* Files */
@@ -220,12 +234,6 @@ task packageDist(type: Zip) {
     }
     into("${parentDir}/bre/lib") {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
-        fileMode = 0644
-    }
-
-    /* Standard Libraries */
-    into("${parentDir}/bre/lib") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -285,8 +293,17 @@ task packageDistZip(type: Zip) {
     }
 
     /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
+    stdLibConfigs.each { stdLibConfig ->
+        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def breLibSourcePath = stdLibConfig.breLibSourcePath
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+            from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
     }
 
     /* Tools artifacts */
@@ -330,12 +347,6 @@ task packageDistZip(type: Zip) {
     }
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
-        fileMode = 0644
-    }
-
-    /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -419,8 +430,17 @@ task packageDistLinux(type: Zip) {
     }
 
     /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
+    stdLibConfigs.each { stdLibConfig ->
+        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def breLibSourcePath = stdLibConfig.breLibSourcePath
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+            from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
     }
 
     /* Tools artifacts */
@@ -466,13 +486,6 @@ task packageDistLinux(type: Zip) {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
         fileMode = 0644
     }
-
-    /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
-        fileMode = 0644
-    }
-
 
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
@@ -549,8 +562,17 @@ task packageDistMac(type: Zip) {
     }
 
     /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
+    stdLibConfigs.each { stdLibConfig ->
+        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def breLibSourcePath = stdLibConfig.breLibSourcePath
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+            from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
     }
 
     /* Tools artifacts */
@@ -591,13 +613,6 @@ task packageDistMac(type: Zip) {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
         fileMode = 0644
     }
-
-    /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
-        fileMode = 0644
-    }
-
 
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
@@ -674,8 +689,17 @@ task packageDistWindows(type: Zip) {
     }
 
     /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
+    stdLibConfigs.each { stdLibConfig ->
+        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def breLibSourcePath = stdLibConfig.breLibSourcePath
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+            from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
     }
 
     /* Tools artifacts */
@@ -714,12 +738,6 @@ task packageDistWindows(type: Zip) {
     }
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
-        fileMode = 0644
-    }
-
-    /* Standard Libraries */
-    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -928,8 +946,8 @@ unpackDockerAnnotations.dependsOn unpackAwsLambdaExamples
 unpackDockerExamples.dependsOn unpackDockerAnnotations
 unpackKubernetesAnnotations.dependsOn unpackDockerExamples
 unpackKubernetesExamples.dependsOn unpackKubernetesAnnotations
-unpackSocketBallerina.dependsOn unpackKubernetesExamples
-unpackBalCommand.dependsOn unpackSocketBallerina
+unpackStdLibs.dependsOn unpackKubernetesExamples
+unpackBalCommand.dependsOn unpackStdLibs
 
 /* Extract JRE */
 extractJreForLinux.dependsOn unpackBalCommand

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -103,6 +103,14 @@ task unpackKubernetesExamples(type: Copy) {
     }
 }
 
+task unpackSocketGenerator(type: Copy) {
+    group = "unpack_dependencies"
+    configurations.socketGenerator.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+        from zipTree(artifact.getFile())
+        into new File("${buildDir}/target/extracted-distributions", artifact.name+"-zip")
+    }
+}
+
 task unpackBalCommand(type: Copy) {
     group = "unpack_dependencies"
     configurations.balCommand.resolvedConfiguration.resolvedArtifacts.each { artifact ->
@@ -179,6 +187,11 @@ task packageDist(type: Zip) {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/awslambda"
     }
 
+    /* Standard Libraries */
+    into("${parentDir}/bir-cache/ballerina/socket") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+    }
+
     /* Files */
     into("${parentDir}/lib/") {
         from "lib/version.txt"
@@ -207,6 +220,12 @@ task packageDist(type: Zip) {
     }
     into("${parentDir}/bre/lib") {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
+        fileMode = 0644
+    }
+
+    /* Standard Libraries */
+    into("${parentDir}/bre/lib") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -265,6 +284,11 @@ task packageDistZip(type: Zip) {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/awslambda"
     }
 
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+    }
+
     /* Tools artifacts */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}") {
         from "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaVersion}"
@@ -308,6 +332,13 @@ task packageDistZip(type: Zip) {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
         fileMode = 0644
     }
+
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        fileMode = 0644
+    }
+
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
         fileMode = 0644
@@ -387,6 +418,11 @@ task packageDistLinux(type: Zip) {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/awslambda"
     }
 
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+    }
+
     /* Tools artifacts */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}") {
         from "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaVersion}"
@@ -430,6 +466,14 @@ task packageDistLinux(type: Zip) {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
         fileMode = 0644
     }
+
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        fileMode = 0644
+    }
+
+
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
         fileMode = 0644
@@ -504,6 +548,11 @@ task packageDistMac(type: Zip) {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/awslambda"
     }
 
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+    }
+
     /* Tools artifacts */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}") {
         from "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaVersion}"
@@ -542,6 +591,14 @@ task packageDistMac(type: Zip) {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
         fileMode = 0644
     }
+
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        fileMode = 0644
+    }
+
+
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
         fileMode = 0644
@@ -616,6 +673,11 @@ task packageDistWindows(type: Zip) {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/awslambda"
     }
 
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+    }
+
     /* Tools artifacts */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}") {
         from "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaVersion}"
@@ -654,6 +716,13 @@ task packageDistWindows(type: Zip) {
         from "build/target/extracted-distributions/kubernetes-extension-annotations-zip/ballerina.knative.jar"
         fileMode = 0644
     }
+
+    /* Standard Libraries */
+    into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
+        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        fileMode = 0644
+    }
+
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
         fileMode = 0644
@@ -859,7 +928,8 @@ unpackDockerAnnotations.dependsOn unpackAwsLambdaExamples
 unpackDockerExamples.dependsOn unpackDockerAnnotations
 unpackKubernetesAnnotations.dependsOn unpackDockerExamples
 unpackKubernetesExamples.dependsOn unpackKubernetesAnnotations
-unpackBalCommand.dependsOn unpackKubernetesExamples
+unpackSocketGenerator.dependsOn unpackKubernetesExamples
+unpackBalCommand.dependsOn unpackSocketGenerator
 
 /* Extract JRE */
 extractJreForLinux.dependsOn unpackBalCommand

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -43,7 +43,6 @@ def ballerinaWindowsDistributionZip = file("$project.buildDir/distributions/ball
 def stdLibInputFile = new File("${project.rootDir}/ballerina/resources/stdlib-configs.json")
 def stdLibConfigs = new JsonSlurper().parseText(stdLibInputFile.text)
 
-
 task unpackBallerinaJre(type: Copy) {
     group = "unpack_dependencies"
     configurations.ballerinaJre.resolvedConfiguration.resolvedArtifacts.each { artifact ->

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -103,9 +103,9 @@ task unpackKubernetesExamples(type: Copy) {
     }
 }
 
-task unpackSocketGenerator(type: Copy) {
+task unpackSocketBallerina(type: Copy) {
     group = "unpack_dependencies"
-    configurations.socketGenerator.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+    configurations.socketBallerina.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         from zipTree(artifact.getFile())
         into new File("${buildDir}/target/extracted-distributions", artifact.name+"-zip")
     }
@@ -189,7 +189,7 @@ task packageDist(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
     }
 
     /* Files */
@@ -225,7 +225,7 @@ task packageDist(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/bre/lib") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -286,7 +286,7 @@ task packageDistZip(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
     }
 
     /* Tools artifacts */
@@ -335,7 +335,7 @@ task packageDistZip(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -420,7 +420,7 @@ task packageDistLinux(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
     }
 
     /* Tools artifacts */
@@ -469,7 +469,7 @@ task packageDistLinux(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -550,7 +550,7 @@ task packageDistMac(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
     }
 
     /* Tools artifacts */
@@ -594,7 +594,7 @@ task packageDistMac(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -675,7 +675,7 @@ task packageDistWindows(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/ballerina/socket") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina/socket"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina/socket"
     }
 
     /* Tools artifacts */
@@ -719,7 +719,7 @@ task packageDistWindows(type: Zip) {
 
     /* Standard Libraries */
     into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
-        from "build/target/extracted-distributions/socket-generator-zip/ballerina.socket.jar"
+        from "build/target/extracted-distributions/socket-ballerina-zip/ballerina.socket.jar"
         fileMode = 0644
     }
 
@@ -928,8 +928,8 @@ unpackDockerAnnotations.dependsOn unpackAwsLambdaExamples
 unpackDockerExamples.dependsOn unpackDockerAnnotations
 unpackKubernetesAnnotations.dependsOn unpackDockerExamples
 unpackKubernetesExamples.dependsOn unpackKubernetesAnnotations
-unpackSocketGenerator.dependsOn unpackKubernetesExamples
-unpackBalCommand.dependsOn unpackSocketGenerator
+unpackSocketBallerina.dependsOn unpackKubernetesExamples
+unpackBalCommand.dependsOn unpackSocketBallerina
 
 /* Extract JRE */
 extractJreForLinux.dependsOn unpackBalCommand

--- a/ballerina/resources/stdlib-configs.json
+++ b/ballerina/resources/stdlib-configs.json
@@ -1,0 +1,13 @@
+[
+  {
+    "organization": "ballerina",
+    "moduleName": "socket",
+    "cache": {
+      "bre": {
+        "sourceDir": "socket-ballerina-zip/ballerina/socket",
+        "targetDir": "ballerina/socket"
+      }
+    },
+    "breLibSourcePath": "socket-ballerina-zip/ballerina.socket.jar"
+  }
+]

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,14 @@ subprojects {
                 password System.getenv("packagePAT")
             }
         }
+        /* Ballerina standard library package links */
+        maven {
+            url "https://maven.pkg.github.com/ballerina-platform/module-ballerina-socket"
+            credentials {
+                username System.getenv("packageUser")
+                password System.getenv("packagePAT")
+            }
+        }
     }
 
     configurations {
@@ -117,7 +125,7 @@ subprojects {
         dockerExamples
         kubernetesAnnotations
         kubernetesExamples
-        socketBallerina
+        ballerinaStdLibs
         balCommand
         exten {
             transitive = false
@@ -149,7 +157,7 @@ subprojects {
         /* Standard libraries */
         exten "org.ballerinalang:socket-native:${socketVersion}"
         exten "org.ballerinalang:socket-test-utils:${socketVersion}"
-        socketBallerina "org.ballerinalang:socket-ballerina:${socketVersion}"
+        ballerinaStdLibs "org.ballerinalang:socket-ballerina:${socketVersion}"
 
         balCommand "org.ballerinalang:ballerina-command-distribution:${ballerinaCommandVersion}@zip"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -142,9 +142,6 @@ subprojects {
         dockerAnnotations "org.ballerinax.docker:docker-extension-annotations:${dockerVersion}@zip"
         dockerExamples "org.ballerinax.docker:docker-extension-examples:${dockerVersion}@zip"
 
-        exten "org.ballerina.socket:socket-utils:${socketVersion}"
-        socketGenerator "org.ballerina.socket:socket-generator:${socketVersion}"
-
         /* Kubernetes extension */
         exten "org.ballerinax.kubernetes:kubernetes-extension:${kubernetesVersion}@jar"
         kubernetesAnnotations "org.ballerinax.kubernetes:kubernetes-extension-annotations:${kubernetesVersion}@zip"

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ ext {
     netLingalaZip4jVersion = "2.3.2"
     commonsIoVersion = "2.6"
     commonsLang3Version = "3.9"
+    socketVersion="1.3.0-SNAPSHOT"
 }
 
 allprojects {
@@ -116,6 +117,8 @@ subprojects {
         dockerExamples
         kubernetesAnnotations
         kubernetesExamples
+        socketUtils
+        socketGenerator
         balCommand
         exten {
             transitive = false
@@ -139,10 +142,17 @@ subprojects {
         dockerAnnotations "org.ballerinax.docker:docker-extension-annotations:${dockerVersion}@zip"
         dockerExamples "org.ballerinax.docker:docker-extension-examples:${dockerVersion}@zip"
 
+        exten "org.ballerina.socket:socket-utils:${socketVersion}"
+        socketGenerator "org.ballerina.socket:socket-generator:${socketVersion}"
+
         /* Kubernetes extension */
         exten "org.ballerinax.kubernetes:kubernetes-extension:${kubernetesVersion}@jar"
         kubernetesAnnotations "org.ballerinax.kubernetes:kubernetes-extension-annotations:${kubernetesVersion}@zip"
         kubernetesExamples "org.ballerinax.kubernetes:kubernetes-extension-examples:${kubernetesVersion}@zip"
+
+        /* Standard libraries */
+        exten "org.ballerina.socket:socket-utils:${socketVersion}"
+        socketGenerator "org.ballerina.socket:socket-generator:${socketVersion}"
 
         balCommand "org.ballerinalang:ballerina-command-distribution:${ballerinaCommandVersion}@zip"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     netLingalaZip4jVersion = "2.3.2"
     commonsIoVersion = "2.6"
     commonsLang3Version = "3.9"
-    socketVersion="1.3.0-SNAPSHOT"
+    socketVersion=project.version
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -117,8 +117,7 @@ subprojects {
         dockerExamples
         kubernetesAnnotations
         kubernetesExamples
-        socketUtils
-        socketGenerator
+        socketBallerina
         balCommand
         exten {
             transitive = false
@@ -148,8 +147,9 @@ subprojects {
         kubernetesExamples "org.ballerinax.kubernetes:kubernetes-extension-examples:${kubernetesVersion}@zip"
 
         /* Standard libraries */
-        exten "org.ballerina.socket:socket-utils:${socketVersion}"
-        socketGenerator "org.ballerina.socket:socket-generator:${socketVersion}"
+        exten "org.ballerinalang:socket-native:${socketVersion}"
+        exten "org.ballerinalang:socket-test-utils:${socketVersion}"
+        socketBallerina "org.ballerinalang:socket-ballerina:${socketVersion}"
 
         balCommand "org.ballerinalang:ballerina-command-distribution:${ballerinaCommandVersion}@zip"
     }


### PR DESCRIPTION
## Purpose
$subject

## Goals
Pack standard library socket external module to the final pack.

## Approach
- Include build configs (zip, mac, linux, and windows)

## Related PRs
- https://github.com/ballerina-platform/module-ballerina-socket/pull/2
- https://github.com/ballerina-platform/ballerina-lang/pull/22782

## Test environment
- Java 8
- Ballerina 1.2.0
- MacOS
 
## Learning
Find more details about this migration here [1].

[1] https://groups.google.com/forum/#!topic/ballerina-dev/RssHIxkR1XA