### PR TITLE
Pack socket API docs and fix jar path

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -196,11 +196,16 @@ task packageDist(type: Zip) {
         def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
+        def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/bir-cache/${birCacheTargetDir}") {
             from "build/target/extracted-distributions/${birCacheSourceDir}"
         }
         into("${parentDir}/bre/lib") {
             from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
+        into("${parentDir}/docs") {
+            from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
         }
     }
@@ -296,11 +301,16 @@ task packageDistZip(type: Zip) {
         def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
+        def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
             from "build/target/extracted-distributions/${birCacheSourceDir}"
         }
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
             from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
+            from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
         }
     }
@@ -433,11 +443,16 @@ task packageDistLinux(type: Zip) {
         def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
+        def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
             from "build/target/extracted-distributions/${birCacheSourceDir}"
         }
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
             from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
+            from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
         }
     }
@@ -565,11 +580,16 @@ task packageDistMac(type: Zip) {
         def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
+        def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
             from "build/target/extracted-distributions/${birCacheSourceDir}"
         }
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
             from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
+            from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
         }
     }
@@ -692,11 +712,16 @@ task packageDistWindows(type: Zip) {
         def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
+        def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
             from "build/target/extracted-distributions/${birCacheSourceDir}"
         }
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bre/lib") {
             from "build/target/extracted-distributions/${breLibSourcePath}"
+            fileMode = 0644
+        }
+        into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
+            from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
         }
     }

--- a/ballerina/resources/stdlib-configs.json
+++ b/ballerina/resources/stdlib-configs.json
@@ -8,6 +8,7 @@
         "targetDir": "ballerina/socket"
       }
     },
-    "breLibSourcePath": "socket-ballerina-zip/ballerina-socket-0.6.0.jar"
+    "breLibSourcePath": "socket-ballerina-zip/ballerina-socket-0.6.0.jar",
+    "apiDocsPath": "socket-ballerina-zip/docs"
   }
 ]

--- a/ballerina/resources/stdlib-configs.json
+++ b/ballerina/resources/stdlib-configs.json
@@ -8,6 +8,6 @@
         "targetDir": "ballerina/socket"
       }
     },
-    "breLibSourcePath": "socket-ballerina-zip/ballerina.socket.jar"
+    "breLibSourcePath": "socket-ballerina-zip/ballerina-socket-0.6.0.jar"
   }
 ]


### PR DESCRIPTION
## Purpose
$subject

## Approach
- Change the jar path in the config file
- Use socket API docs in the artifact

## Related PRs
- https://github.com/ballerina-platform/module-ballerina-socket/pull/8

## Related Issues
- https://github.com/ballerina-platform/ballerina-lang/issues/23506

## Test environment
- Java 8
- Ballerina 2.0.0-SNAPSHOT
- macOS