### PR TITLE
Introduce common cache for balos, birs, and jars

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -890,167 +890,211 @@ artifacts {
     ballerinaWindowsDistribution file: ballerinaWindowsDistributionZip, builtBy: packageDistWindows
 }
 
-task testExamples {
+task testExamples() {
 
-     def baseBuildPath = "${project.rootDir}/ballerina/build/target/extracted-distributions/jballerina-tools-zip"
-     def distPath = "${baseBuildPath}/jballerina-tools-${ballerinaVersion}"
-     def bbeList = []
+    def jballerinaPack = "${project.rootDir}/ballerina/build/target/extracted-distributions/jballerina-tools-zip"
+    def baseBuildPath = "${project.rootDir}/ballerina/build/bbe-pack"
+    def distPath = "${baseBuildPath}/jballerina-tools-${ballerinaVersion}"
+    def bbeList = []
 
-     outputs.dir("${distPath}/examples/target")
-     outputs.dir("${distPath}/examples/.ballerina/repo/")
-     outputs.cacheIf { true }
+    PatternSet patternSet = new PatternSet();
+    patternSet.exclude("**/.ballerina/**");
+    patternSet.exclude("**/Ballerina.toml");
+    patternSet.exclude("**/Ballerina.lock");
+    patternSet.exclude("**/ballerina-internal.log")
+    inputs.files(files("${distPath}/examples").asFileTree.matching(patternSet))
+    def ignoreList = [
+         'proto-to-ballerina',
+         'swagger-to-ballerina',
+         'taint-checking',
+         'websub-hub-client-sample',
+         'websub-remote-hub-sample',
+         'config-api',
+         'testerina-function-mocks',
+         'jdbc-client-crud-operations',
+         'jdbc-client-batch-update',
+         'jdbc-client-call-procedures',
+         'streaming-big-dataset',
+         'docker-deployment',
+         'kubernetes-deployment',
+         'knative-deployment',
+         'awslambda-deployment',
+         'openshift-deployment',
+         'grpc-server-streaming',
+         'transactions-distributed',
+         'local-transactions',
+         'local-transactions-with-participants',
+         'xa-transactions',
+         'secured-client-with-oauth2',
+         'gauge-metrics',
+         'counter-metrics',
+         'openapi-to-ballerina',
+         'kafka_message_consumer_group_service',
+         'kafka_message_consumer_simple',
+         'kafka_message_consumer_service',
+         'kafka_message_producer',
+         'kafka_message_producer_transactional',
+         'grpc-secured-unary',
+         'grpc-bidirectional-streaming',
+         'grpc-client-streaming',
+         'grpc-unary-non-blocking',
+         'grpc-unary-blocking',
+         'testerina-guarantee-test-execution-order',
+         'testerina-data-driven-tests',
+         'testerina-before-and-after-suite',
+         'testerina-before-each-test',
+         'testerina-before-and-after-test',
+         'testerina-assertions',
+         'taint-checking',
+         'secured-service-with-basic-auth',
+         'secured-service-with-jwt-auth',
+         'secured-client-with-basic-auth',
+         'secured-client-with-jwt-auth',
+         'http-caching-client',
+         'http-data-binding',
+         'http-1.1-to-2.0-protocol-switch',
+         'http-to-websocket-upgrade',
+         'basic-https-listener-client',
+         'https-listener',
+         'http-client-endpoint',
+         'http-redirects',
+         'http-2-0-server-push',
+         'websocket-basic-sample',
+         'websocket-proxy-server',
+         'websocket-failover',
+         'websocket-chat-application',
+         'response-with-multiparts',
+         'tracing',
+         'log-api',
+         'the-main-function',
+         'task-scheduler-appointment',
+         'task-scheduler-timer',
+         'time',
+         'crypto',
+         'xml-functions',
+         'xml-access',
+         'header-based-routing',
+         'mutual-ssl',
+         'tuple-match-statement',
+         'type-conversion',
+         'filepath',
+         'record-io',
+         'csv-io',
+         'type-cast',
+         'async',
+         'json-csv',
+         'worker-interaction',
+         'fork-variable-access',
+         'functional-iteration',
+         'table',
+         'maps',
+         'cache',
+         'send-and-receive-emails',
+         'xml-attributes',
+         'xml-literal',
+         'xml',
+         'json-to-xml-conversion',
+         'length',
+         'foreach',
+         'testerina-group-tests',
+         'json-record-map-conversion'
+    ]
+    doFirst {
+        copy {
+            from jballerinaPack
+            into baseBuildPath
+        }
+        exec {
+            //Initialize Ballerina project
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                //TODO: Need to verify with windows
+                workingDir "${baseBuildPath}"
+                commandLine 'cmd', '/c', "jballerina-tools-${ballerinaVersion}/bin/ballerina.bat", 'new', 'TestProject'
+            } else {
+                workingDir "${baseBuildPath}"
+                commandLine 'sh', '-c', "jballerina-tools-${ballerinaVersion}/bin/ballerina new TestProject"
+            }
+        }
 
-     PatternSet patternSet = new PatternSet();
-     patternSet.exclude("**/.ballerina/**");
-     patternSet.exclude("**/Ballerina.toml");
-     patternSet.exclude("**/Ballerina.lock");
-     patternSet.exclude("**/ballerina-internal.log")
-     inputs.files(files("${distPath}/examples").asFileTree.matching(patternSet))
-     def ignoreList = [
-             'proto-to-ballerina',
-             'swagger-to-ballerina',
-             'taint-checking',
-             'websub-hub-client-sample',
-             'websub-remote-hub-sample',
-             'config-api',
-             'testerina-function-mocks',
-             'jdbc-client-crud-operations',
-             'jdbc-client-batch-update',
-             'jdbc-client-call-procedures',
-             'streaming-big-dataset',
-             'docker-deployment',
-             'kubernetes-deployment',
-             'knative-deployment',
-             'awslambda-deployment',
-             'openshift-deployment',
-             'grpc-server-streaming',
-             'transactions-distributed',
-             'local-transactions',
-             'local-transactions-with-participants',
-             'xa-transactions',
-             'secured-client-with-oauth2',
-             'gauge-metrics',
-             'counter-metrics',
-             'openapi-to-ballerina',
-             'kafka_message_consumer_group_service',
-             'kafka_message_consumer_simple',
-             'kafka_message_consumer_service',
-             'kafka_message_producer',
-             'kafka_message_producer_transactional',
-             'grpc-secured-unary',
-             'grpc-bidirectional-streaming',
-             'grpc-client-streaming',
-             'grpc-unary-non-blocking',
-             'grpc-unary-blocking',
-             'testerina-guarantee-test-execution-order',
-             'testerina-data-driven-tests',
-             'testerina-before-and-after-suite',
-             'testerina-before-each-test',
-             'testerina-before-and-after-test',
-             'testerina-assertions',
-             'taint-checking',
-             'secured-service-with-basic-auth',
-             'secured-service-with-jwt-auth',
-             'secured-client-with-basic-auth',
-             'secured-client-with-jwt-auth',
-             'http-caching-client',
-             'http-data-binding',
-             'http-1.1-to-2.0-protocol-switch',
-             'http-to-websocket-upgrade',
-             'basic-https-listener-client',
-             'https-listener',
-             'http-client-endpoint',
-             'http-redirects',
-             'http-2.0-server-push',
-             'websocket-basic-sample',
-             'websocket-proxy-server',
-             'websocket-failover',
-             'websocket-chat-application',
-             'response-with-multiparts',
-             'tracing',
-             'log-api',
-             'the-main-function',
-             'task-scheduler-appointment',
-             'task-scheduler-timer',
-             'time',
-             'crypto',
-             'xml-functions',
-             'xml-access',
-             'header-based-routing',
-             'mutual-ssl',
-             'tuple-match-statement',
-             'type-conversion',
-             'filepath',
-             'record-io',
-             'csv-io',
-             'type-cast',
-             'async',
-             'json-csv',
-             'worker-interaction',
-             'fork-variable-access',
-             'functional-iteration',
-             'table',
-             'maps',
-             'cache',
-             'send-and-receive-emails',
-             'xml-attributes',
-             'xml-literal',
-             'xml',
-             'json-to-xml-conversion',
-             'length',
-             'foreach',
-             'testerina-group-tests'
-     ]
-     doFirst {
-         exec {
-             //Initialize Ballerina project
-             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                 //TODO: Need to verify with windows
-                 workingDir "${baseBuildPath}"
-                 commandLine 'cmd', '/c', "jballerina-tools-${ballerinaVersion}/bin/ballerina.bat", 'new', 'TestProject'
-             } else {
-                 workingDir "${baseBuildPath}"
-                 commandLine "jballerina-tools-${ballerinaVersion}/bin/./ballerina", 'new', 'TestProject'
-             }
-         }
-         def src = "${project.rootDir}/examples/"
-         def dis = "${baseBuildPath}/TestProject/src/"
-         copy {
-             from(src)
-             into dis
-         }
-         def inputFile = new File("${baseBuildPath}/TestProject/src/index.json")
-         def categories = new JsonSlurper().parseText(inputFile.text)
-         categories.each { category ->
-             def examples = category.samples
-             examples.each { example ->
-                 def folder = new File("${baseBuildPath}/TestProject/src/${example.url}")
-                 if (folder.exists()) {
-                     bbeList.push("$example.url")
-                 }
-             }
-         }
-     }
-     doLast {
-         ignoreList.each { String elements ->
-             bbeList.remove("$elements")
-         }
-         bbeList.each { String bbe ->
-             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                 //TODO: Need to verify with windows
-                 exec {
-                     workingDir "${buildDir}/TestProject"
-                     commandLine 'cmd', '/c', "${distPath}/bin/ballerina.bat", 'build', '--experimental', "${bbe}"
-                 }
-             } else {
-                 exec {
-                     workingDir "${baseBuildPath}/TestProject"
-                     commandLine "../jballerina-tools-${ballerinaVersion}/bin/./ballerina", 'build', '--experimental', "${bbe}"
-                 }
-             }
-         }
-     }
- }
+        def tomlFile = new File("${baseBuildPath}/TestProject/Ballerina.toml")
+        def src = "${project.rootDir}/examples/"
+        def dis = "${baseBuildPath}/TestProject/src/"
+        copy {
+            from(src)
+            into dis
+        }
+        def inputFile = new File("${baseBuildPath}/TestProject/src/index.json")
+        def categories = new JsonSlurper().parseText(inputFile.text)
+        categories.each { category ->
+            def examples = category.samples
+            examples.each { example ->
+                def folder = new File("${baseBuildPath}/TestProject/src/${example.url}")
+                if (folder.exists()) {
+                    bbeList.push("$example.url")
+                }
+            }
+        }
+    }
+    doLast {
+        def birCache = new File("${distPath}/cache/bir/")
+        def baloCache = new File("${distPath}/cache/balo/")
+        def jarCache = new File("${distPath}/cache/jar/")
+        stdLibConfigs.each { stdLibConfig ->
+            def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
+            def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
+            def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
+            def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
+            def jarCacheSourceDir = stdLibConfig.cache.jar.sourceDir
+            def jarCacheTargetDir = stdLibConfig.cache.jar.targetDir
+            def breLibSourcePath = stdLibConfig.breLibSourcePath
+            def apiDocsPath = stdLibConfig.apiDocsPath
+            copy {
+                from "build/target/extracted-distributions/${birCacheSourceDir}"
+                into "${distPath}/bir-cache/${birCacheTargetDir}"
+            }
+            copy {
+                from "build/target/extracted-distributions/${breLibSourcePath}"
+                into "${distPath}/bre/lib"
+                fileMode = 0644
+            }
+            copy {
+                from "build/target/extracted-distributions/${apiDocsPath}"
+                into "${distPath}/docs"
+            }
+
+            // pack to new cache
+            copy {
+                from "build/target/extracted-distributions/${birCacheSourceDir}"
+                into "${birCache}/${birCacheTargetDir}"
+            }
+            copy {
+                from "build/target/extracted-distributions/${baloCacheSourceDir}"
+                into "${baloCache}/${baloCacheTargetDir}"
+            }
+            copy {
+                from "build/target/extracted-distributions/${jarCacheSourceDir}"
+                into "${jarCache}/${jarCacheTargetDir}"
+            }
+        }
+        ignoreList.each { String elements ->
+            bbeList.remove("$elements")
+        }
+        bbeList.each { String bbe ->
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                //TODO: Need to verify with windows
+                exec {
+                    workingDir "${buildDir}/TestProject"
+                    commandLine 'cmd', '/c', "${distPath}/bin/ballerina.bat", 'build', '--experimental', "${bbe}"
+                }
+            } else {
+                exec {
+                    workingDir "${baseBuildPath}/TestProject"
+                    commandLine 'sh', '-c', "../jballerina-tools-${ballerinaVersion}/bin/ballerina build --experimental ${bbe}"
+                }
+            }
+        }
+    }
+}
 
 /* Unpack Dependencies */
 unpackJballerinaTools.dependsOn unpackBallerinaJre

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -194,11 +194,14 @@ task packageDist(type: Zip) {
     /* Standard Libraries */
     def birCache = new File("${parentDir}/cache/bir/")
     def baloCache = new File("${parentDir}/cache/balo/")
+    def jarCache = new File("${parentDir}/cache/balo/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
         def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
         def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
+        def jarCacheSourceDir = stdLibConfig.cache.jar.sourceDir
+        def jarCacheTargetDir = stdLibConfig.cache.jar.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/bir-cache/${birCacheTargetDir}") {
@@ -219,6 +222,9 @@ task packageDist(type: Zip) {
         }
         into("${baloCache}/${baloCacheTargetDir}") {
             from "build/target/extracted-distributions/${baloCacheSourceDir}"
+        }
+        into("${jarCache}/${jarCacheTargetDir}") {
+            from "build/target/extracted-distributions/${jarCacheSourceDir}"
         }
     }
 
@@ -311,11 +317,14 @@ task packageDistZip(type: Zip) {
     /* Standard Libraries */
     def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
     def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
+    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
         def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
         def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
+        def jarCacheSourceDir = stdLibConfig.cache.jar.sourceDir
+        def jarCacheTargetDir = stdLibConfig.cache.jar.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -336,6 +345,9 @@ task packageDistZip(type: Zip) {
         }
         into("${baloCache}/${baloCacheTargetDir}") {
             from "build/target/extracted-distributions/${baloCacheSourceDir}"
+        }
+        into("${jarCache}/${jarCacheTargetDir}") {
+            from "build/target/extracted-distributions/${jarCacheSourceDir}"
         }
     }
 
@@ -465,11 +477,14 @@ task packageDistLinux(type: Zip) {
     /* Standard Libraries */
     def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
     def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
+    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
         def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
         def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
+        def jarCacheSourceDir = stdLibConfig.cache.jar.sourceDir
+        def jarCacheTargetDir = stdLibConfig.cache.jar.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -490,6 +505,9 @@ task packageDistLinux(type: Zip) {
         }
         into("${baloCache}/${baloCacheTargetDir}") {
             from "build/target/extracted-distributions/${baloCacheSourceDir}"
+        }
+        into("${jarCache}/${jarCacheTargetDir}") {
+            from "build/target/extracted-distributions/${jarCacheSourceDir}"
         }
     }
 
@@ -614,11 +632,14 @@ task packageDistMac(type: Zip) {
     /* Standard Libraries */
     def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
     def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
+    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
         def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
         def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
+        def jarCacheSourceDir = stdLibConfig.cache.jar.sourceDir
+        def jarCacheTargetDir = stdLibConfig.cache.jar.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -639,6 +660,9 @@ task packageDistMac(type: Zip) {
         }
         into("${baloCache}/${baloCacheTargetDir}") {
             from "build/target/extracted-distributions/${baloCacheSourceDir}"
+        }
+        into("${jarCache}/${jarCacheTargetDir}") {
+            from "build/target/extracted-distributions/${jarCacheSourceDir}"
         }
     }
 
@@ -758,11 +782,14 @@ task packageDistWindows(type: Zip) {
     /* Standard Libraries */
     def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
     def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
+    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
         def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
         def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
+        def jarCacheSourceDir = stdLibConfig.cache.jar.sourceDir
+        def jarCacheTargetDir = stdLibConfig.cache.jar.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -783,6 +810,9 @@ task packageDistWindows(type: Zip) {
         }
         into("${baloCache}/${baloCacheTargetDir}") {
             from "build/target/extracted-distributions/${baloCacheSourceDir}"
+        }
+        into("${jarCache}/${jarCacheTargetDir}") {
+            from "build/target/extracted-distributions/${jarCacheSourceDir}"
         }
     }
 

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -192,9 +192,10 @@ task packageDist(type: Zip) {
     }
 
     /* Standard Libraries */
-    def birCache = new File("${parentDir}/cache/bir/")
-    def baloCache = new File("${parentDir}/cache/balo/")
-    def jarCache = new File("${parentDir}/cache/balo/")
+    def jBallerinaCacheDir = "${parentDir}/cache"
+    def birCache = new File("${jBallerinaCacheDir}/bir/")
+    def baloCache = new File("${jBallerinaCacheDir}/balo/")
+    def jarCache = new File("${jBallerinaCacheDir}/balo/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
@@ -315,9 +316,10 @@ task packageDistZip(type: Zip) {
     }
 
     /* Standard Libraries */
-    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
-    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
-    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
+    def jBallerinaCacheDir = "${parentDir}/distributions/jballerina-${ballerinaVersion}/cache"
+    def birCache = new File("${jBallerinaCacheDir}/bir/")
+    def baloCache = new File("${jBallerinaCacheDir}/balo/")
+    def jarCache = new File("${jBallerinaCacheDir}/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
@@ -475,9 +477,10 @@ task packageDistLinux(type: Zip) {
     }
 
     /* Standard Libraries */
-    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
-    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
-    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
+    def jBallerinaCacheDir = "${parentDir}/distributions/jballerina-${ballerinaVersion}/cache"
+    def birCache = new File("${jBallerinaCacheDir}/bir/")
+    def baloCache = new File("${jBallerinaCacheDir}/balo/")
+    def jarCache = new File("${jBallerinaCacheDir}/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
@@ -630,9 +633,10 @@ task packageDistMac(type: Zip) {
     }
 
     /* Standard Libraries */
-    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
-    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
-    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
+    def jBallerinaCacheDir = "${parentDir}/distributions/jballerina-${ballerinaVersion}/cache"
+    def birCache = new File("${jBallerinaCacheDir}/bir/")
+    def baloCache = new File("${jBallerinaCacheDir}/balo/")
+    def jarCache = new File("${jBallerinaCacheDir}/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
@@ -780,9 +784,10 @@ task packageDistWindows(type: Zip) {
     }
 
     /* Standard Libraries */
-    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
-    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
-    def jarCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/jar/")
+    def jBallerinaCacheDir = "${parentDir}/distributions/jballerina-${ballerinaVersion}/cache"
+    def birCache = new File("${jBallerinaCacheDir}/bir/")
+    def baloCache = new File("${jBallerinaCacheDir}/balo/")
+    def jarCache = new File("${jBallerinaCacheDir}/jar/")
     stdLibConfigs.each { stdLibConfig ->
         def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
         def birCacheTargetDir = stdLibConfig.cache.bir.targetDir

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -192,9 +192,13 @@ task packageDist(type: Zip) {
     }
 
     /* Standard Libraries */
+    def birCache = new File("${parentDir}/cache/bir/")
+    def baloCache = new File("${parentDir}/cache/balo/")
     stdLibConfigs.each { stdLibConfig ->
-        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
-        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
+        def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
+        def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/bir-cache/${birCacheTargetDir}") {
@@ -207,6 +211,14 @@ task packageDist(type: Zip) {
         into("${parentDir}/docs") {
             from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
+        }
+
+        // pack to new cache
+        into("${birCache}/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${baloCache}/${baloCacheTargetDir}") {
+            from "build/target/extracted-distributions/${baloCacheSourceDir}"
         }
     }
 
@@ -297,9 +309,13 @@ task packageDistZip(type: Zip) {
     }
 
     /* Standard Libraries */
+    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
+    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
     stdLibConfigs.each { stdLibConfig ->
-        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
-        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
+        def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
+        def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -312,6 +328,14 @@ task packageDistZip(type: Zip) {
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
             from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
+        }
+
+        // pack to new cache
+        into("${birCache}/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${baloCache}/${baloCacheTargetDir}") {
+            from "build/target/extracted-distributions/${baloCacheSourceDir}"
         }
     }
 
@@ -439,9 +463,13 @@ task packageDistLinux(type: Zip) {
     }
 
     /* Standard Libraries */
+    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
+    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
     stdLibConfigs.each { stdLibConfig ->
-        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
-        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
+        def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
+        def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -454,6 +482,14 @@ task packageDistLinux(type: Zip) {
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
             from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
+        }
+
+        // pack to new cache
+        into("${birCache}/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${baloCache}/${baloCacheTargetDir}") {
+            from "build/target/extracted-distributions/${baloCacheSourceDir}"
         }
     }
 
@@ -576,9 +612,13 @@ task packageDistMac(type: Zip) {
     }
 
     /* Standard Libraries */
+    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
+    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
     stdLibConfigs.each { stdLibConfig ->
-        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
-        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
+        def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
+        def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -591,6 +631,14 @@ task packageDistMac(type: Zip) {
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
             from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
+        }
+
+        // pack to new cache
+        into("${birCache}/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${baloCache}/${baloCacheTargetDir}") {
+            from "build/target/extracted-distributions/${baloCacheSourceDir}"
         }
     }
 
@@ -708,9 +756,13 @@ task packageDistWindows(type: Zip) {
     }
 
     /* Standard Libraries */
+    def birCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/bir/")
+    def baloCache = new File("${parentDir}/distributions/jballerina-${ballerinaVersion}/cache/balo/")
     stdLibConfigs.each { stdLibConfig ->
-        def birCacheSourceDir = stdLibConfig.cache.bre.sourceDir
-        def birCacheTargetDir = stdLibConfig.cache.bre.targetDir
+        def birCacheSourceDir = stdLibConfig.cache.bir.sourceDir
+        def birCacheTargetDir = stdLibConfig.cache.bir.targetDir
+        def baloCacheSourceDir = stdLibConfig.cache.balo.sourceDir
+        def baloCacheTargetDir = stdLibConfig.cache.balo.targetDir
         def breLibSourcePath = stdLibConfig.breLibSourcePath
         def apiDocsPath = stdLibConfig.apiDocsPath
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/bir-cache/${birCacheTargetDir}") {
@@ -723,6 +775,14 @@ task packageDistWindows(type: Zip) {
         into("${parentDir}/distributions/jballerina-${ballerinaVersion}/docs") {
             from "build/target/extracted-distributions/${apiDocsPath}"
             fileMode = 0644
+        }
+
+        // pack to new cache
+        into("${birCache}/${birCacheTargetDir}") {
+            from "build/target/extracted-distributions/${birCacheSourceDir}"
+        }
+        into("${baloCache}/${baloCacheTargetDir}") {
+            from "build/target/extracted-distributions/${baloCacheSourceDir}"
         }
     }
 

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -1002,7 +1002,12 @@ task testExamples() {
          'length',
          'foreach',
          'testerina-group-tests',
-         'json-record-map-conversion'
+         'json-record-map-conversion',
+         'http-timeout',
+         'http-retry',
+         'http-failover',
+         'http-load-balancer',
+         'http-circuit-breaker'
     ]
     doFirst {
         copy {

--- a/ballerina/resources/stdlib-configs.json
+++ b/ballerina/resources/stdlib-configs.json
@@ -3,12 +3,16 @@
     "organization": "ballerina",
     "moduleName": "socket",
     "cache": {
-      "bre": {
-        "sourceDir": "socket-ballerina-zip/ballerina/socket",
+      "bir": {
+        "sourceDir": "socket-ballerina-zip/caches/bir/ballerina/socket",
+        "targetDir": "ballerina/socket"
+      },
+      "balo": {
+        "sourceDir": "socket-ballerina-zip/caches/balo/ballerina/socket",
         "targetDir": "ballerina/socket"
       }
     },
-    "breLibSourcePath": "socket-ballerina-zip/ballerina-socket-0.6.0.jar",
+    "breLibSourcePath": "socket-ballerina-zip/libs",
     "apiDocsPath": "socket-ballerina-zip/docs"
   }
 ]

--- a/ballerina/resources/stdlib-configs.json
+++ b/ballerina/resources/stdlib-configs.json
@@ -10,6 +10,10 @@
       "balo": {
         "sourceDir": "socket-ballerina-zip/caches/balo/ballerina/socket",
         "targetDir": "ballerina/socket"
+      },
+      "jar": {
+        "sourceDir": "socket-ballerina-zip/caches/jar/ballerina/socket",
+        "targetDir": "ballerina/socket"
       }
     },
     "breLibSourcePath": "socket-ballerina-zip/libs",

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     netLingalaZip4jVersion = "2.3.2"
     commonsIoVersion = "2.6"
     commonsLang3Version = "3.9"
-    socketVersion="2.0.0-Preview1-M4"
+    socketVersion= project.stdlibSocketVersion
 }
 
 allprojects {
@@ -163,8 +163,6 @@ subprojects {
         kubernetesExamples "org.ballerinax.kubernetes:kubernetes-extension-examples:${kubernetesVersion}@zip"
 
         /* Standard libraries */
-        exten "org.ballerinalang:socket-native:${socketVersion}"
-        exten "org.ballerinalang:socket-test-utils:${socketVersion}"
         ballerinaStdLibs "org.ballerinalang:socket-ballerina:${socketVersion}"
 
         balCommand "org.ballerinalang:ballerina-command-distribution:${ballerinaCommandVersion}@zip"

--- a/examples/index.json
+++ b/examples/index.json
@@ -553,7 +553,7 @@
             },
             {
                 "name": "Java Arrays",
-                "url": "java-arrays"
+                "url": "java.arrays"
             },
             {
                 "name": "Java Varargs",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=1.3.0-SNAPSHOT
+stdlibSocketVersion=0.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=2.0.0-SNAPSHOT
-stdlibSocketVersion=0.6.0
+stdlibSocketVersion=0.6.1-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=1.3.0-SNAPSHOT
+version=2.0.0-SNAPSHOT
 stdlibSocketVersion=0.6.0


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/23648

## Approach
Currently, pack the socket balos and birs as follows:

```
jballerina-2.0.0-SNAPSHOT/cache/
├── balo
│   └── ballerina
│       └── socket
│           └── 0.6.0
│               ├── Ballerina.toml
│               └── socket-2020r1-java8-0.6.0.balo
└── bir
    └── ballerina
        └── socket
            └── 0.6.0
```

## Test environment
- Java 8
- Ballerina 2.0.0-SNAPSHOT
- ballerina/socket 0.6.0
- macOS
 