### PR TITLE
Migrate `__init` methods to `init`

### DIFF
--- a/examples/abstract-objects/abstract_objects.bal
+++ b/examples/abstract-objects/abstract_objects.bal
@@ -24,7 +24,7 @@ type Employee object {
     public string lastName;
 
     // Non-abstract objects can have initializers.
-    function __init(int age, string firstName, string lastName) {
+    function init(int age, string firstName, string lastName) {
         self.age = age;
         self.firstName = firstName;
         self.lastName = lastName;

--- a/examples/anonymous-objects/anonymous_objects.bal
+++ b/examples/anonymous-objects/anonymous_objects.bal
@@ -12,7 +12,7 @@ public type Person record {
         public string city;
         public string country;
 
-        public function __init(string city, string country) {
+        public function init(string city, string country) {
             self.city = city;
             self.country = country;
         }
@@ -39,7 +39,7 @@ public function main() {
         public string city;
         public string country;
 
-        public function __init(string city, string country) {
+        public function init(string city, string country) {
             self.city = city;
             self.country = country;
         }

--- a/examples/any-type/any_type.bal
+++ b/examples/any-type/any_type.bal
@@ -4,7 +4,7 @@ type Person object {
     string fname;
     string lname;
 
-    function __init(string fname, string lname) {
+    function init(string fname, string lname) {
         self.fname = fname;
         self.lname = lname;
     }

--- a/examples/object-assignability/object_assignability.bal
+++ b/examples/object-assignability/object_assignability.bal
@@ -16,7 +16,7 @@ public type Employee object {
     public string name;
     public string address;
 
-    public function __init(int age, string name, string address) {
+    public function init(int age, string name, string address) {
         self.age = age;
         self.name = name;
         self.address = address;

--- a/examples/object-initializer/object_initializer.bal
+++ b/examples/object-initializer/object_initializer.bal
@@ -1,14 +1,14 @@
 import ballerina/io;
 
-// Defines an object called `Person`. Each object has its own `__init()` method, which gets
+// Defines an object called `Person`. Each object has its own `init()` method, which gets
 // invoked when creating the objects. You can place the logic for initializing the fields of the
-// object within the body of the `__init()` method.
+// object within the body of the `init()` method.
 type Person object {
 
     public string name;
     private int age;
 
-    function __init(string name, int age) returns error? {
+    function init(string name, int age) returns error? {
         self.name = name;
         self.age = check validateAge(age);
     }
@@ -24,7 +24,7 @@ function validateAge(int age) returns int|error {
 }
 
 public function main() {
-    // Since the `__init()` method potentially returns an `error`, the `p1` variable should
+    // Since the `init()` method potentially returns an `error`, the `p1` variable should
     // be of the type `Person|error`.
     Person|error p1 = new("John", 25);
     if (p1 is Person) {

--- a/examples/object-methods/object_methods.bal
+++ b/examples/object-methods/object_methods.bal
@@ -7,7 +7,7 @@ type Person object {
     public string lastName;
 
     // The object initializer.
-    function __init(int age, string firstName, string lastName) {
+    function init(int age, string firstName, string lastName) {
         self.age = age;
         self.firstName = firstName;
         self.lastName = lastName;

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -39,7 +39,7 @@ type Manager object {
     public string dpt;
 
     // All the fields referenced through the type reference can be accessed within this object.
-    function __init(int age, string firstName, string lastName, string status) {
+    function init(int age, string firstName, string lastName, string status) {
         self.age = age;
         self.firstName = firstName;
         self.lastName = lastName;


### PR DESCRIPTION
## Purpose
Object `__init` method is changed to `init`. This PR fixes it in BBEs.
Refer: https://github.com/ballerina-platform/ballerina-lang/issues/23358