### PR TITLE
Cannot create methods outside objects now

### DIFF
--- a/examples/object-methods/object_methods.description
+++ b/examples/object-methods/object_methods.description
@@ -1,3 +1,1 @@
 // Objects can have functions associated with them. These associated functions are known as methods.
-// Methods can be defined inside or outside the object. To define a method outside the object,
-// first declare the method signature inside the object.


### PR DESCRIPTION
## Purpose
Update object methods description

> ## Summary of changes from 2019R1 to 2019R2
> The ability to define a method outside the object type has been removed.
