### PR TITLE
Update details of BBE : Objects can now refer non-abstract objects

### DIFF
--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -23,8 +23,8 @@ type Employee abstract object {
     function getSalary() returns float;
 };
 
-type Owner abstract object {
-    public string status;
+type Owner object {
+    public string status = "";
 };
 
 type Manager object {

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -56,7 +56,8 @@ type Manager object {
         return self.firstName + " " + self.lastName;
     }
 
-    // refered methods can be overridden with a subtype method
+    // Referenced methods can also be overridden as long the method in the overriding 
+    // descriptor is a sub-type of the method in the referenced type.
     function getSalary() returns float {
         return self.salary;
     }

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -18,9 +18,9 @@ type Employee abstract object {
     // Add a reference to the `Person` object type. 
     // All the member fields and member methods will be copied from the `Person` object.
     *Person;
-    public float|int salary;
+    public float|string salary;
 
-    function getSalary() returns float|int;
+    function getSalary() returns float|string;
 };
 
 type Owner object {

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -47,7 +47,7 @@ type Manager object {
         self.firstName = firstName;
         self.lastName = lastName;
         self.status = status;
-        self.salary = 2000;
+        self.salary = 2000.0;
         self.dpt = "HR";
     }
 

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -15,7 +15,7 @@ type Person abstract object {
 
 // Defines another abstract object called `Employee`, which references the `Person` object.
 type Employee abstract object {
-    // Add a reference to the `Person` object type. Only abstract objects can be referred.
+    // Add a reference to the `Person` object type. 
     // All the member fields and member methods will be copied from the `Person` object.
     *Person;
     public float salary;

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -57,7 +57,7 @@ type Manager object {
         return self.firstName + " " + self.lastName;
     }
 
-    // Referenced methods can also be overridden as long the method in the overriding 
+    // Referenced methods can also be overridden as long as the method in the overriding 
     // descriptor is a sub-type of the method in the referenced type.
     function getSalary() returns float {
         return self.salary;

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -18,9 +18,9 @@ type Employee abstract object {
     // Add a reference to the `Person` object type. 
     // All the member fields and member methods will be copied from the `Person` object.
     *Person;
-    public float salary;
+    public float|int salary;
 
-    function getSalary() returns float;
+    function getSalary() returns float|int;
 };
 
 type Owner object {
@@ -38,8 +38,11 @@ type Manager object {
 
     public string dpt;
 
+    // referenced fields can be overridden by subtypes
+    public float salary;
+
     // All the fields referenced through the type reference can be accessed within this object.
-    function __init(int age, string firstName, string lastName, string status) {
+    function init(int age, string firstName, string lastName, string status) {
         self.age = age;
         self.firstName = firstName;
         self.lastName = lastName;
@@ -53,6 +56,7 @@ type Manager object {
         return self.firstName + " " + self.lastName;
     }
 
+    // refered methods can be overridden with a subtype method
     function getSalary() returns float {
         return self.salary;
     }

--- a/examples/object-type-reference/object_type_reference.bal
+++ b/examples/object-type-reference/object_type_reference.bal
@@ -38,7 +38,8 @@ type Manager object {
 
     public string dpt;
 
-    // referenced fields can be overridden by subtypes
+    // Referenced fields can be overridden in a type-descriptor if the type of the field  
+    // in the overriding descriptor is a sub-type of the original type of the field.
     public float salary;
 
     // All the fields referenced through the type reference can be accessed within this object.

--- a/examples/object-type-reference/object_type_reference.description
+++ b/examples/object-type-reference/object_type_reference.description
@@ -2,3 +2,5 @@
 // into another object. It is equivalent to specifying the members explicitly
 // within the new object, thus, eliminating redundancy. An object can have
 // zero or more type references and may have chained references as well.
+// Fields and method definitions can override referenced fields and methods
+// provided that they are subtypes of referenced types.

--- a/examples/object-type-reference/object_type_reference.description
+++ b/examples/object-type-reference/object_type_reference.description
@@ -1,4 +1,4 @@
 // Object type references provide a way to copy the members from an object 
-// into another object. It is equivalent to specifying the members 
-// explicitly within the new object, thus, eliminating redundancy. An object can have
+// into another object. It is equivalent to specifying the members explicitly
+// within the new object, thus, eliminating redundancy. An object can have
 // zero or more type references and may have chained references as well.

--- a/examples/object-type-reference/object_type_reference.description
+++ b/examples/object-type-reference/object_type_reference.description
@@ -1,4 +1,4 @@
-// Object type references provide a way to copy the members from an abstract 
-// object into another object. It is equivalent to specifying the members 
+// Object type references provide a way to copy the members from an object 
+// into another object. It is equivalent to specifying the members 
 // explicitly within the new object, thus, eliminating redundancy. An object can have
 // zero or more type references and may have chained references as well.

--- a/examples/object-type-reference/object_type_reference.description
+++ b/examples/object-type-reference/object_type_reference.description
@@ -3,4 +3,4 @@
 // within the new object, thus, eliminating redundancy. An object can have
 // zero or more type references and may have chained references as well.
 // Fields and method definitions can override referenced fields and methods
-// provided that they are subtypes of referenced types.
+// provided that they are sub-types of referenced field/method types.


### PR DESCRIPTION
## Purpose
Objects can now include non-abstract objects. This PR updates description.

Refer spec change: https://github.com/ballerina-platform/ballerina-lang/issues/23359

May need to improve the BBEs too.