### PR TITLE
Remove binding patters from let-expression BBE

### DIFF
--- a/examples/let-expression/let_expression.bal
+++ b/examples/let-expression/let_expression.bal
@@ -36,10 +36,6 @@ public function main() {
               } = getPerson()
               in personAge;
     io:println("age: ", age);
-
-    var fatal = let var error(reason, ...params) = getSampleError()
-                    in params["fatal"];
-    io:println("fatal: ", fatal);
 }
 
 public function getInt() returns int => 1;

--- a/examples/let-expression/let_expression.out
+++ b/examples/let-expression/let_expression.out
@@ -7,4 +7,3 @@ three: 3
 length: 14
 tuple binding result: 60
 age: 31
-fatal: true


### PR DESCRIPTION
## Purpose
The new parser does not support binding patterns. Hence removing from this example temporary.