### PR TITLE
Enable packing index.json to the final packs

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -209,7 +209,6 @@ task packageDist(type: Zip) {
     }
     into("${parentDir}/examples") {
         from "${project.rootDir}/examples/"
-        exclude "index.json"
         fileMode = 0755
     }
     into("${parentDir}/examples") {
@@ -421,7 +420,6 @@ task packageDistLinux(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        exclude "index.json"
         fileMode = 0755
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
@@ -539,7 +537,6 @@ task packageDistMac(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        exclude "index.json"
         fileMode = 0755
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
@@ -652,7 +649,6 @@ task packageDistWindows(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        exclude "index.json"
         fileMode = 0755
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24373


## Approach
Pack `index.json` to final packs.

Note that, there has been a recent fix to change the jBallerina path as well. The BBE path with that recent fix as follows:

```sh
ballerina-swan-lake-preview1-SNAPSHOT/distributions/ballerina-slp1/examples/index.json
```

## Test environment
Ballerina swan-lake preview1-M6