### PR TITLE
Update comment on Kakfa examples ignoring

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -857,7 +857,7 @@ task testExamples() {
         'kafka-producer-transactional',
         'kafka-consumer-group-service',
         'kafka-authentication-sasl-plain-consumer',
-        'kafka-authentication-sasl-plain-producer',     // Kafka bbes are ignored coz it needs avro dependency
+        'kafka-authentication-sasl-plain-producer', // Kafka BBEs are ignored since a KafkaCluster is not present
         'config-api',
         'docker-deployment',
         'kubernetes-deployment',


### PR DESCRIPTION
## Purpose
> The Kafka BBEs are ignored in tests, because to Kafka BBEs to run, there should be an active Kafka cluster is running