### PR TITLE
Fix a bug in BBE verification logic

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -844,7 +844,7 @@ task testExamples() {
     patternSet.exclude("**/ballerina-internal.log")
     inputs.files(files("${distPath}/examples").asFileTree.matching(patternSet))
 
-    // The following BBEs will not be verified by running/compiling
+    // The following BBEs will not be verified by compiling/running.
     def buildIgnoreList = [
         'proto-to-ballerina',
         'taint-checking',
@@ -931,8 +931,8 @@ task testExamples() {
         'while'
     ]
 
-    // The following BBEs will only be verified by compiling
-    def runIgnoreList = [
+    // The following BBEs will be excluded from output verification. But will be verified by compiling and running.
+    def outputVerificationIgnoreList = [
         'websub-service-integration-sample',
         'websub-internal-hub-sample',
         'grpc-server-streaming',
@@ -1200,12 +1200,11 @@ task testExamples() {
         def failedBuildExamples = []
         def failOutputVerificationExamples = []
         bbeList.each { String bbe ->
-            if (runIgnoreList.contains(bbe)) {
-                boolean buildFailFlag = buildBBE(bbe)
-                if (buildFailFlag) {
-                    failedBuildExamples.add(bbe)
-                }
-            } else {
+            boolean buildFailFlag = buildBBE(bbe)
+            if (buildFailFlag) {
+                failedBuildExamples.add(bbe)
+            }
+            if (!outputVerificationIgnoreList.contains(bbe)) {
                 boolean outputVerificationFailFlag = outputVerification(bbe)
                 if (outputVerificationFailFlag) {
                     failOutputVerificationExamples.add(bbe)


### PR DESCRIPTION
## Purpose
The existing logic is as follows:
If a BBE is in the `buildIgnoreList` it is skipped from compiling and running at all. Then the remaining BBEs are considered for further actions.
- If remaining BBEs are in the `runIgnoreList`, they are tested after compiling. (run test cases)
- If remaining BBEs are not in `runIgnoreList`, they are used for output verification after compiling.

This logic skip compiling and testing (run test cases) the BBEs which are not in the `runIgnoreList`.

The updated logic will do followings:

If a BBE is in the `buildIgnoreList` it is skipped from compiling and running at all. Then the remaining BBEs are considered for further actions.
- Compile and test (run test cases) all the remaining BBEs.
- If remaining BBEs are not in the `outputVerificationIgnoreList`, they are used for output verification also.