### PR TITLE
Add a test to check the existance of the Email library

### DIFF
--- a/stdlib-integration-tests/email/tests/email_test.bal
+++ b/stdlib-integration-tests/email/tests/email_test.bal
@@ -1,0 +1,19 @@
+import ballerina/email;
+import ballerina/test;
+
+@test:Config {}
+function testEmail() {
+    email:SmtpClient smtpClient = new ("smtp.email.com", "sender@email.com"
+        , "pass123");
+    email:Email email = {
+        to: ["receiver1@email.com", "receiver2@email.com"],
+        cc: ["receiver3@email.com", "receiver4@email.com"],
+        bcc: ["receiver5@email.com"],
+        subject: "Sample Email",
+        body: "This is a sample email.",
+        'from: "author@email.com",
+        sender: "sender@email.com",
+        replyTo: ["replyTo1@email.com", "replyTo2@email.com"]
+    };
+    test:assertEquals(email.subject, "Sample Email");
+}

--- a/stdlib-integration-tests/index.json
+++ b/stdlib-integration-tests/index.json
@@ -4,6 +4,10 @@
     "path": "socket"
   },
   {
+    "name": "Email standard library ",
+    "path": "email"
+  },
+  {
     "name": "Auth standard library ",
     "path": "auth"
   },


### PR DESCRIPTION
## Purpose
Add a test to verify the existence of the Email library. Resolves https://github.com/ballerina-platform/module-ballerina-email/issues/14