### PR TITLE
Add a simple FTP module test to test the existence of the FTP module

### DIFF
--- a/stdlib-integration-tests/ftp/tests/ftp_test.bal
+++ b/stdlib-integration-tests/ftp/tests/ftp_test.bal
@@ -1,0 +1,13 @@
+import ballerina/ftp;
+import ballerina/test;
+
+@test:Config {}
+function testFtp() {
+    ftp:ClientEndpointConfig config = {
+            protocol: ftp:FTP,
+            host: "127.0.0.1",
+            port: 21212,
+            secureSocket: {basicAuth: {username: "wso2", password: "wso2123"}}
+    };
+    test:assertEquals(config.host, "127.0.0.1");
+}


### PR DESCRIPTION
## Purpose
Add a simple FTP test to make sure FTP module is included in the standard library distribution.
