### PR TITLE
Ignore the connection close in websocket test

### DIFF
--- a/stdlib-integration-tests/websocket/tests/web_socket_test.bal
+++ b/stdlib-integration-tests/websocket/tests/web_socket_test.bal
@@ -41,5 +41,5 @@ public function testString() {
     checkpanic wsClient->pushText("Hi");
     runtime:sleep(500);
     test:assertEquals(data, "Hi", msg = "Failed pushtext");
-    checkpanic wsClient->close(statusCode = 1000, reason = "Close the connection");
+    var closeResp = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 180);
 }


### PR DESCRIPTION
## Purpose
Ignoring as this is not required for that test. Having this will intermittently fail the build because when the network is slow it takes a lot of time to send back the close frame.