### PR TITLE
Update API Doc Guidelines for Examples

### DIFF
--- a/doc-guidelines.md
+++ b/doc-guidelines.md
@@ -190,19 +190,6 @@ After writing a Ballerina By Example, you can also run it to test and verify if 
 
 5. You should not try to refer to examples in BBEs here with links, but rather have separate examples. This is because the required examples will probably not match the examples in the BBEs in the first place. The API docs will probably have more examples, when it explains each API operation etc. Also, users will not want to click another link and navigate away from the API docs to a separate BBE page. Rather, they will need to see the example in the same place where the API is described. 
 
-6. In scenarios such as error value returns, all possible error types and their scenarios should be mentioned clearly. There should not be statements such as “returns error when something goes wrong”. 
+6. The examples should be self-contained. They should contain a fully working program when an example is given, such as all the imports, and a main function. The Ballerina documentation generator can later remove any redundant code segments in a post-processing operation. This is required, since this code should be runnable from the documentation website. 
 
-7. Always, add a full stop at the end of a function description. However, as a best practice, omit the full stop if you have only one sentence in the parameter and return type descriptions. If there are multiple sentences for a parameter or return type description, add the full stop at the end of the first sentence and in the succeding ones. For example,
-
-    ```ballerina
-    # Description for the function.
-    #
-    # + i - One sentence only
-    # + s - Sentence one. Sentence two.
-    # + return - Return description
-    public function foo(int i, string s) returns boolean {
-        return true;
-    }
-    ```
-
-
+7. In scenarios such as error value returns, all possible error types and their scenarios should be mentioned clearly. There should not be statements such as “returns error when something goes wrong”. 


### PR DESCRIPTION
* Update API doc guidelines for examples
* Remove redundant information regarding function description formatting - already available in https://ballerina.io/learn/documenting-ballerina-code/. 