### PR TITLE
Improve RabbitMQ producer example

### DIFF
--- a/examples/rabbitmq-producer/rabbitmq_producer.bal
+++ b/examples/rabbitmq-producer/rabbitmq_producer.bal
@@ -5,53 +5,33 @@ public function main() {
     // Creates a ballerina RabbitMQ connection that allows re-usability if necessary.
     rabbitmq:Connection connection = new ({host: "localhost", port: 5672});
 
-    // Creates multiple ballerina RabbitMQ channels.
-    rabbitmq:Channel newChannel1 = new (connection);
-    rabbitmq:Channel newChannel2 = new (connection);
+    // Creates a ballerina RabbitMQ channel.
+    rabbitmq:Channel newChannel = new (connection);
 
-    // Declares the queue, MyQueue1.
-    var queueResult1 = newChannel1->queueDeclare({queueName: "MyQueue1"});
-    if (queueResult1 is error) {
-        io:println("An error occurred while creating the MyQueue1 queue.");
+    // Declares the queue, MyQueue.
+    string|rabbitmq:Error? queueResult =
+            newChannel->queueDeclare({queueName: "MyQueue"});
+    if (queueResult is error) {
+        io:println("An error occurred while creating the queue.");
     }
 
-    // Declares the queue, MyQueue2.
-    var queueResult2 = newChannel2->queueDeclare({queueName: "MyQueue2"});
-    if (queueResult2 is error) {
-        io:println("An error occurred while creating the MyQueue2 queue.");
+    // Declares the direct exchange, MyExchange.
+    rabbitmq:Error? exchangeResult =
+            newChannel->exchangeDeclare({exchangeName: "MyExchange",
+                                      exchangeType: rabbitmq:DIRECT_EXCHANGE });
+    if (exchangeResult is error) {
+        io:println("An error occurred while creating the exchange.");
     }
 
-    // Publishing messages to an exchange using a routing key.
-    // Publishes the message using newChannel1 and the routing key named MyQueue1.
-    worker w1 {
-        var sendResult = newChannel1->basicPublish("Hello from Ballerina",
-                                        "MyQueue1");
-        if (sendResult is error) {
-            io:println("An error occurred while sending the message to " +
-                     "MyQueue1 using newChannel1.");
-        }
-    }
+    // Binds MyQueue to MyExchange with the routing key named example-key.
+    rabbitmq:Error? bindResult =
+            newChannel->queueBind("MyQueue", "MyExchange", "example-key");
 
-    // Publishing messages to the same routing key using a different channel.
-    // Publishes the message using newChannel2 and the same routing key named MyQueue1.
-    worker w2 {
-        var sendResult = newChannel2->basicPublish("Hello from Ballerina",
-                                        "MyQueue1");
-        if (sendResult is error) {
-            io:println("An error occurred while sending the message to " +
-                    "MyQueue1 using newChannel2.");
-        }
+    // Publishes the message to the routing key example-key using newChannel.
+    rabbitmq:Error? sendResult = newChannel->basicPublish("Hello from Ballerina",
+                                      "example-key", "MyExchange");
+    if (sendResult is error) {
+        io:println("An error occurred while sending the message to " +
+                    "example-key using newChannel.");
     }
-
-    // Publishing messages to different routing keys using the same channel.
-    // Publishes the message using newChannel1 to a different routing key named MyQueue2.
-    worker w3 {
-        var sendResult = newChannel1->basicPublish("Hello from Ballerina",
-                                        "MyQueue2");
-        if (sendResult is error) {
-            io:println("An error occurred while sending the message to " +
-                    "MyQueue2 using newChannel1.");
-        }
-    }
-    _ = wait {w1, w2, w3};
 }


### PR DESCRIPTION
## Purpose
This fix is to address the following concerns.
- The existing example is too complex
- There is no example with the use of exchanges 
- The existing producer does not match the consumer example (the current producer is sending messages to MyQueue1 and MyQueue2, the consumer is listening to MyQueue)

Running the new example with the [consumer example](https://github.com/ballerina-platform/ballerina-distribution/blob/master/examples/rabbitmq-consumer/rabbitmq_consumer.bal) will work seamlessly
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/478