### PR TITLE
Add socket IO tests and upgrade versions

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -910,8 +910,6 @@ task testExamples() {
         'tracing',
         'openapi-to-ballerina',
         'taint-checking', // Should not compile
-        'websub-service-integration-sample',
-        'websub-internal-hub-sample',
         'task-service-appointment',
         'task-scheduler-appointment',
         'user-defined-error'

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -909,7 +909,12 @@ task testExamples() {
         'counter-metrics',
         'tracing',
         'openapi-to-ballerina',
-        'taint-checking' // Should not compile
+        'taint-checking', // Should not compile
+        'websub-service-integration-sample',
+        'websub-internal-hub-sample',
+        'task-service-appointment',
+        'task-scheduler-appointment',
+        'user-defined-error'
     ]
 
     // The following BBEs will be excluded from output verification, which means verifying the output of the `.bal` file

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,6 @@ version=swan-lake-preview6-SNAPSHOT
 ballerinaVersion=2.0.0-Preview6-SNAPSHOT
 shortVersion=slp6
 
-# Following have already been released to ballerina central
-stdlibSocketVersion=0.7.0-SNAPSHOT
-stdlibEncodingVersion=1.0.4-SNAPSHOT
-stdlibJwtVersion=1.0.4-SNAPSHOT
-stdlibWebsubVersion=1.0.4-SNAPSHOT
-stdlibRabbitmqVersion=1.0.5-SNAPSHOT
-stdlibNatsVersion=1.0.3-SNAPSHOT
-
 # Stdlib Level 01
 stdlibJavaArraysVersion=0.9.2-SNAPSHOT
 stdlibJsonUtilsVersion=1.0.2-SNAPSHOT
@@ -20,6 +12,7 @@ stdlibMathVersion=1.0.2-SNAPSHOT
 stdlibIoVersion=0.5.2-SNAPSHOT
 stdlibStringutilsVersion=0.5.2-SNAPSHOT
 stdlibRuntimeVersion=0.5.2-SNAPSHOT
+stdlibEncodingVersion=1.0.4-SNAPSHOT
 
 # Stdlib Level 02
 stdlibSystemVersion=0.6.2-SNAPSHOT
@@ -40,6 +33,9 @@ stdlibReflectVersion=0.5.2-SNAPSHOT
 stdlibMimeVersion=1.0.2-SNAPSHOT
 stdlibFilepathVersion=0.7.3-SNAPSHOT
 stdlibCacheVersion=2.0.2-SNAPSHOT
+stdlibSocketVersion=0.7.0-SNAPSHOT
+stdlibNatsVersion=1.0.3-SNAPSHOT
+stdlibRabbitmqVersion=1.0.5-SNAPSHOT
 stdlibFtpVersion=1.0.1-SNAPSHOT
 
 # Stdlib Level 06
@@ -53,6 +49,8 @@ stdlibLdapVersion=1.0.2-SNAPSHOT
 stdlibHttpVersion=1.0.2-SNAPSHOT
 
 # Stdlib Level 08
+stdlibWebsubVersion=1.0.5-SNAPSHOT
+stdlibJwtVersion=1.0.4-SNAPSHOT
 stdlibOAuth2Version=1.0.2-SNAPSHOT
 stdlibGrpcVersion=0.7.2-SNAPSHOT
 stdlibJdbcVersion=0.5.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,44 +1,59 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=swan-lake-preview6-SNAPSHOT
-ballerinaVersion=2.0.0-Preview5
-shortVersion=slp5
+ballerinaVersion=2.0.0-Preview6-SNAPSHOT
+shortVersion=slp6
 
 # Following have already been released to ballerina central
-stdlibSocketVersion=0.6.9
-stdlibEncodingVersion=1.0.3
-stdlibJwtVersion=1.0.3
-stdlibWebsubVersion=1.0.3
-stdlibRabbitmqVersion=1.0.4
-stdlibNatsVersion=1.0.2
+stdlibSocketVersion=0.7.0-SNAPSHOT
+stdlibEncodingVersion=1.0.4-SNAPSHOT
+stdlibJwtVersion=1.0.4-SNAPSHOT
+stdlibWebsubVersion=1.0.4-SNAPSHOT
+stdlibRabbitmqVersion=1.0.5-SNAPSHOT
+stdlibNatsVersion=1.0.3-SNAPSHOT
 
-stdlibXsltVersion=1.0.2
-stdlibFileVersion=0.5.2
-stdlibTimeVersion=1.0.2
-stdlibFilepathVersion=0.7.2
-stdlibTaskVersion=1.1.1
-stdlibCacheVersion=2.0.1
-stdlibSystemVersion=0.6.1
-stdlibRuntimeVersion=0.5.1
-stdlibConfigVersion=1.0.1
-stdlibSqlVersion=0.5.1
-stdlibJdbcVersion=0.5.1
-stdlibMySqlVersion=0.6.1
-stdlibKafkaVersion=2.0.1
-stdlibMathVersion=1.0.1
-stdlibJsonUtilsVersion=1.0.1
-stdlibXmlUtilsVersion=1.0.1
-stdlibLogVersion=1.0.1
-stdlibReflectVersion=0.5.1
-stdlibIoVersion=0.5.1
-stdlibStringutilsVersion=0.5.1
-stdlibAuthVersion=1.0.1
-stdlibOAuth2Version=1.0.1
-stdlibLdapVersion=1.0.1
-stdlibCryptoVersion=1.0.1
-stdlibJavaArraysVersion=0.9.1
-stdlibMimeVersion=1.0.1
-stdlibEmailVersion=1.0.1
-stdlibFtpVersion=1.0.0
-stdlibHttpVersion=1.0.1
-stdlibGrpcVersion=0.7.1
+# Stdlib Level 01
+stdlibJavaArraysVersion=0.9.2-SNAPSHOT
+stdlibJsonUtilsVersion=1.0.2-SNAPSHOT
+stdlibXmlUtilsVersion=1.0.2-SNAPSHOT
+stdlibMathVersion=1.0.2-SNAPSHOT
+stdlibIoVersion=0.5.2-SNAPSHOT
+stdlibStringutilsVersion=0.5.2-SNAPSHOT
+stdlibRuntimeVersion=0.5.2-SNAPSHOT
+
+# Stdlib Level 02
+stdlibSystemVersion=0.6.2-SNAPSHOT
+stdlibTimeVersion=1.0.3-SNAPSHOT
+stdlibXsltVersion=1.0.3-SNAPSHOT
+stdlibTaskVersion=1.1.2-SNAPSHOT
+
+# Stdlib Level 03
+stdlibConfigVersion=1.0.2-SNAPSHOT
+stdlibFileVersion=0.5.3-SNAPSHOT
+stdlibCryptoVersion=1.0.2-SNAPSHOT
+
+# Stdlib Level 04
+stdlibLogVersion=1.0.2-SNAPSHOT
+stdlibReflectVersion=0.5.2-SNAPSHOT
+
+# Stdlib Level 05
+stdlibMimeVersion=1.0.2-SNAPSHOT
+stdlibFilepathVersion=0.7.3-SNAPSHOT
+stdlibCacheVersion=2.0.2-SNAPSHOT
+stdlibFtpVersion=1.0.1-SNAPSHOT
+
+# Stdlib Level 06
+stdlibEmailVersion=1.0.2-SNAPSHOT
+stdlibKafkaVersion=2.0.2-SNAPSHOT
+stdlibAuthVersion=1.0.2-SNAPSHOT
+
+# Stdlib Level 07
+stdlibSqlVersion=0.5.2-SNAPSHOT
+stdlibLdapVersion=1.0.2-SNAPSHOT
+stdlibHttpVersion=1.0.2-SNAPSHOT
+
+# Stdlib Level 08
+stdlibOAuth2Version=1.0.2-SNAPSHOT
+stdlibGrpcVersion=0.7.2-SNAPSHOT
+stdlibJdbcVersion=0.5.2-SNAPSHOT
+stdlibMySqlVersion=0.6.2-SNAPSHOT

--- a/stdlib-integration-tests/index.json
+++ b/stdlib-integration-tests/index.json
@@ -96,6 +96,10 @@
     "path": "websub"
   },
   {
+    "name": "IO standard library",
+    "path": "io"
+  },
+  {
     "name": "Config standard library",
     "path": "config"
   }

--- a/stdlib-integration-tests/index.json
+++ b/stdlib-integration-tests/index.json
@@ -36,34 +36,6 @@
     "path": "task"
   },
   {
-    "name": "gRPC Unary Blocking RPC",
-    "path": "grpc-unary-blocking"
-  },
-  {
-    "name": "gRPC Unary non-Blocking RPC",
-    "path": "grpc-unary-non-blocking"
-  },
-  {
-    "name": "gRPC Server Streaming RPC",
-    "path": "grpc-server-streaming"
-  },
-  {
-    "name": "gRPC Unary Secured RPC",
-    "path": "grpc-secured-unary"
-  },
-  {
-    "name": "gRPC Client Streaming RPC",
-    "path": "grpc-client-streaming"
-  },
-  {
-    "name": "gRPC Bidirectional Streaming RPC",
-    "path": "grpc-bidirectional-streaming"
-  },
-  {
-    "name": "gRPC service with HTTP gateway",
-    "path": "grpc-service-with-http-proxy-gateway"
-  },
-  {
     "name": "HTTP standard library",
     "path": "http"
   },

--- a/stdlib-integration-tests/io/tests/io_socket_tests.bal
+++ b/stdlib-integration-tests/io/tests/io_socket_tests.bal
@@ -1,0 +1,426 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+import ballerina/socket;
+import ballerina/log;
+import ballerina/lang.'string as langstring;
+
+@test:Config {}
+public function testSocketChannelReadBytes() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    string payload = "Hello Ballerina World!!!!";
+    socketWrite(socketClient, payload);
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadBytes(byteChannel);
+                if (content is byte[]) {
+                    test:assertEquals(content, payload.toBytes());
+                } else {
+                    test:assertFail(msg = content.message());
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadBytes"]}
+public function testSocketChannelReadBytesAsStream() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    string payload = "Hello Ballerina World Again!!!!";
+    socketWrite(socketClient, payload);
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadBlocksAsStream(byteChannel, 1);
+                if (content is stream<io:Block>) {
+                    _ = content.forEach(function(io:Block val) {
+                                           foreach byte b in val {
+                                               byteArr.push(b);
+                                           }
+                                       });
+                    string|error returnedString = langstring:fromBytes(byteArr);
+                    if (returnedString is string) {
+                        log:printInfo(returnedString);
+                        log:printInfo(payload);
+                        test:assertEquals(returnedString, payload);
+                    } else {
+                        test:assertFail(msg = returnedString.message());
+                    }
+                } else if (content is io:Error) {
+                    test:assertFail(msg = content.message());
+                } else {
+                    test:assertFail("Unknown error occured");
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadBytesAsStream"]}
+public function testSocketChannelReadString() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    string payload = "Hello Ballerina World Again!!!!";
+    socketWrite(socketClient, payload);
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadString(byteChannel);
+                if (content is string) {
+                    test:assertEquals(content, payload);
+                } else {
+                    test:assertFail(msg = content.message());
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadString"]}
+public function testSocketChannelReadLines() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    string payload = "F.R.I.E.N.D.S \n The Big Bang Theory \n LOST";
+    string[] expected = ["F.R.I.E.N.D.S", "The Big Bang Theory", "LOST"];
+    socketWrite(socketClient, payload);
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadLines(byteChannel);
+                if (content is string[]) {
+                    int i = 0;
+                    foreach string s in content {
+                        test:assertEquals(langstring:trim(s), expected[i]);
+                        i += 1;
+                    }
+                } else {
+                    test:assertFail(msg = content.message());
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadLines"]}
+public function testSocketChannelReadLinesAsStream() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    string payload = "F.R.I.E.N.D.S \n The Big Bang Theory \n LOST";
+    string[] expected = ["F.R.I.E.N.D.S", "The Big Bang Theory", "LOST"];
+    socketWrite(socketClient, payload);
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadLinesAsStream(byteChannel);
+                if (content is stream<string>) {
+                    int i = 0;
+                    _ = content.forEach(function(string s) {
+                                           test:assertEquals(langstring:trim(s), expected[i]);
+                                           i += 1;
+                                       });
+                } else if (content is io:Error) {
+                    test:assertFail(msg = content.message());
+                } else {
+                    test:assertFail("Unknown error occured");
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadLinesAsStream"]}
+public function testSocketChannelReadJson() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    json payload = {"name": "Sheldon Cooper", "occupation": "Physicist", "age": 32};
+    socketWrite(socketClient, payload.toString());
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadJson(byteChannel);
+                if (content is json) {
+                    test:assertEquals(content, payload);
+                } else {
+                    test:assertFail(msg = content.message());
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadJson"]}
+public function testSocketChannelReadXml() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+
+    xml payload = xml `<CATALOG>
+                       <CD>
+                           <TITLE>Empire Burlesque</TITLE>
+                           <ARTIST>Bob Dylan</ARTIST>
+                           <COUNTRY>USA</COUNTRY>
+                           <COMPANY>Columbia</COMPANY>
+                           <PRICE>10.90</PRICE>
+                           <YEAR>1985</YEAR>
+                       </CD>
+                   </CATALOG>`;
+    socketWrite(socketClient, payload.toString());
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadXml(byteChannel);
+                if (content is xml) {
+                    test:assertEquals(content, payload);
+                } else {
+                    test:assertFail(msg = content.message());
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadXml"]}
+public function testSocketChannelReadCsv() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    string payload = "Anne Hamiltom, Software Engineer, Microsoft, 26 years, New York \n " +
+    "John Thomson, Software Architect, WSO2, 38 years, Colombo \n " +
+    "Mary Thompson, Banker, ABC Bank, 30 years, Colombo";
+
+    string[][] expectedContent = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], [
+    "John Thomson", "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "ABC Bank",
+    "30 years", "Colombo"]];
+    socketWrite(socketClient, payload);
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadCsv(byteChannel);
+                if (content is string[][]) {
+                    int i = 0;
+                    foreach string[] rec in content {
+                        test:assertEquals(langstring:trim(rec[0]), expectedContent[i][0]);
+                        test:assertEquals(langstring:trim(rec[1]), expectedContent[i][1]);
+                        test:assertEquals(langstring:trim(rec[2]), expectedContent[i][2]);
+                        test:assertEquals(langstring:trim(rec[3]), expectedContent[i][3]);
+                        test:assertEquals(langstring:trim(rec[4]), expectedContent[i][4]);
+                        i += 1;
+                    }
+                } else {
+                    test:assertFail(msg = content.message());
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+@test:Config {dependsOn: ["testSocketChannelReadCsv"]}
+public function testSocketChannelReadCsvAsStream() {
+    socket:Client socketClient = new ({
+        host: "localhost",
+        port: 61599
+    });
+    string payload = "Anne Hamiltom, Software Engineer, Microsoft, 26 years, New York \n " +
+    "John Thomson, Software Architect, WSO2, 38 years, Colombo \n " +
+    "Mary Thompson, Banker, ABC Bank, 30 years, Colombo";
+
+    string[][] expectedContent = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], [
+    "John Thomson", "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "ABC Bank",
+    "30 years", "Colombo"]];
+    socketWrite(socketClient, payload);
+    byte[] byteArr = [];
+
+    var result = socketClient->read();
+    if (result is [byte[], int]) {
+        var [reply, length] = result;
+        if (length > 0) {
+            var byteChannel = io:createReadableChannel(reply);
+            if (byteChannel is io:ReadableByteChannel) {
+                var content = io:channelReadCsvAsStream(byteChannel);
+                if (content is stream<string[]>) {
+                    int i = 0;
+                    _ = content.forEach(function(string[] rec) {
+                                           test:assertEquals(langstring:trim(rec[0]), expectedContent[i][0]);
+                                           test:assertEquals(langstring:trim(rec[1]), expectedContent[i][1]);
+                                           test:assertEquals(langstring:trim(rec[2]), expectedContent[i][2]);
+                                           test:assertEquals(langstring:trim(rec[3]), expectedContent[i][3]);
+                                           test:assertEquals(langstring:trim(rec[4]), expectedContent[i][4]);
+                                           i += 1;
+                                       });
+                } else if (content is io:Error) {
+                    test:assertFail(msg = content.message());
+                } else {
+                    test:assertFail("Unknown error occured");
+                }
+            } else {
+                test:assertFail(msg = byteChannel.message());
+            }
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+
+    var closeResult = socketClient->close();
+    if (closeResult is error) {
+        test:assertFail(msg = closeResult.message());
+    }
+}
+
+function socketWrite(socket:Client socketClient, string payload) {
+    byte[] payloadByte = payload.toBytes();
+
+    int i = 0;
+    int arrayLength = payloadByte.length();
+    while (i < arrayLength) {
+        var writeResult = socketClient->write(payloadByte);
+        if !(writeResult is error) {
+            i = i + writeResult;
+            payloadByte = payloadByte.slice(writeResult, arrayLength);
+        } else {
+            log:printError("Unable to write the content to socket: " + payload, writeResult);
+        }
+    }
+}

--- a/stdlib-integration-tests/io/tests/server.bal
+++ b/stdlib-integration-tests/io/tests/server.bal
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/log;
+import ballerina/socket;
+
+service echoServer on new socket:Listener(61599) {
+
+    resource function onConnect(socket:Caller caller) {
+        log:printInfo("Client connected: " + caller.id.toString());
+    }
+
+    resource function onReadReady(socket:Caller caller) {
+        var result = caller->read();
+        if (result is [byte[], int]) {
+            var [content, length] = result;
+            if (length > 0) {
+
+                var byteChannel =
+                io:createReadableChannel(content);
+                if (byteChannel is io:ReadableByteChannel) {
+                    var str = io:channelReadString(byteChannel);
+                    if (str is string) {
+                        string reply = <@untainted>str;
+                        byte[] payloadByte = reply.toBytes();
+
+                        int i = 0;
+                        int arrayLength = payloadByte.length();
+                        while (i < arrayLength) {
+                            var writeResult = caller->write(payloadByte);
+                            if (writeResult is int) {
+                                log:printInfo("Number of bytes written: "
+                                    + writeResult.toString());
+                                i = i + writeResult;
+                                payloadByte = payloadByte.slice(writeResult,
+                                                                arrayLength);
+                            } else {
+                                log:printError("Unable to write the content",
+                                    writeResult);
+                            }
+                        }
+                    } else {
+                        log:printError("Error while writing content to " +
+                                        "the caller", str);
+                    }
+                }
+            } else {
+                log:printInfo("Client left: " + caller.id.toString());
+            }
+        } else {
+            io:println(result);
+        }
+    }
+
+    resource function onError(socket:Caller caller, error er) {
+        log:printError("An error occurred", er);
+    }
+}


### PR DESCRIPTION
## Purpose
- Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/568
- Upgrade stdlib versions

## Approach
Add new channel API tests to test socket and IO compatibility.

## Automation tests
 - Integration tests
   > Yes

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/31

## Test environment
- SLP6
- macOS
- Java11