### PR TITLE
Enable windows builds

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew.bat clean build -x :ballerina:testStdlibs --stacktrace --scan --console=plain --no-daemon -x :ballerina:testExamples
+        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
       - ballerina-1.1.x
 
 jobs:
-  build:
+  ubuntu-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,3 +27,17 @@ jobs:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
+
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-distribution/issues/930

## Approach
- Enable windows builds for PRs and commits
- Enable tests in the windows build of the master branch build

