### PR TITLE
Enable OAuth2 integration tests

### DIFF
--- a/stdlib-integration-tests/index.json
+++ b/stdlib-integration-tests/index.json
@@ -24,6 +24,10 @@
     "path": "jwt"
   },
   {
+    "name": "OAuth2 standard library ",
+    "path": "oauth2"
+  },
+  {
     "name": "LDAP standard library ",
     "path": "ldap"
   },

--- a/stdlib-integration-tests/oauth2/tests/mock-servers/secured_service_with_oauth2.bal
+++ b/stdlib-integration-tests/oauth2/tests/mock-servers/secured_service_with_oauth2.bal
@@ -24,14 +24,11 @@ auth:OutboundBasicAuthProvider basicAuthProvider = new({
     username: "3MVG9YDQS5WtC11paU2WcQjBB3L5w4gz52uriT8ksZ3nUVjKvrfQMrU4uvZohTftxStwNEW4cfStBEGRxRL68",
     password: "9205371918321623741"
 });
-http:BasicAuthHandler basicAuthHandler = new(basicAuthProvider);
 
 oauth2:IntrospectionServerConfig introspectionServerConfig = {
     url: "https://localhost:20299/oauth2/token/introspect",
     clientConfig: {
-        auth: {
-            authHandler: basicAuthHandler
-        },
+        customHeaders: {"Authorization": "Basic " + check basicAuthProvider.generateToken()},
         secureSocket: {
            trustStore: {
                path: TRUSTSTORE_PATH,


### PR DESCRIPTION
## Purpose
This PR enables the OAuth2 integration tests which was disabled by https://github.com/ballerina-platform/ballerina-distribution/pull/937, since it was failing due to the update by https://github.com/ballerina-platform/module-ballerina-oauth2/pull/32