### PR TITLE
Fix BBEs

### DIFF
--- a/examples/foreach/foreach.bal
+++ b/examples/foreach/foreach.bal
@@ -69,21 +69,23 @@ public function main() {
         io:println("Employee: ", employee);
     }
 
-    io:println("\nIterating a closed integer range:- ");
+    io:println("\nIterating an integer range (1 ... endValue):- ");
     int endValue = 10;
     int sum = 0;
-    // A closed integer range in the `foreach` statement represents an incremental integer value range from the start
+    // An integer range `1 ... endValue` in the `foreach` statement represents
+    // an incremental integer value range from the start
     // expression (`1`) to the end expression (`endValue`) inclusively.
-    foreach var i in 1...endValue {
+    foreach var i in 1 ... endValue {
         sum = sum + i;
     }
     io:println("Summation from 1 to ", endValue, " is ", sum);
 
-    io:println("\nIterating a half open integer range:- ");
+    io:println("\nIterating an integer range (1 ..< endValue):- ");
     sum = 0;
-    // A half-open integer range in the `foreach` statement represents an incremental integer value range from the start
-    // expression (`1`) inclusively to the end expression (`endValue`) exclusively.
-    foreach var i in 1..< endValue {
+    // An integer range `1 ..< endValue` in the `foreach` statement represents an
+    // incremental integer value range from the start expression (`1`) inclusively
+    // to the end expression (`endValue`) exclusively.
+    foreach var i in 1 ..< endValue {
         sum = sum + i;
     }
     io:println("Summation from 1 to ", endValue," (exclusive) is ", sum);

--- a/examples/foreach/foreach.out
+++ b/examples/foreach/foreach.out
@@ -24,11 +24,11 @@ Color: red
 Color: green
 
 Iterating an XML:-
-Book:                  <book>
+Book:                   <book>
                            <name>Sherlock Holmes</name>
                            <author>Sir Arthur Conan Doyle</author>
                        </book>
-Book:                  <book>
+Book:                   <book>
                            <name>Harry Potter</name>
                            <author>J.K. Rowling</author>
                        </book>
@@ -38,8 +38,8 @@ Employee: {"id":1,"name":"John","salary":300.5}
 Employee: {"id":2,"name":"Bella","salary":500.5}
 Employee: {"id":3,"name":"Peter","salary":750.0}
 
-Iterating a closed integer range:-
+Iterating an integer range (1 ... endValue):-
 Summation from 1 to 10 is 55
 
-Iterating a half open integer range:-
+Iterating an integer range (1 ..< endValue):-
 Summation from 1 to 10 (exclusive) is 45

--- a/examples/readonly-type/readonly_type.description
+++ b/examples/readonly-type/readonly_type.description
@@ -1,7 +1,9 @@
-// The `readonly` type consists of values whose read-only bit is set.
+// The `readonly` type consists of values that are immutable.
 // `()`, `boolean`, `int`, `float`, `decimal`, `string`, `error`, `function`, `service`, and `typedesc` are
 // considered to be inherently immutable basic types, and a value belonging to an inherently immutable basic type
-// will always have its read-only bit set, and thus will always belong to the `readonly` type.
+// will always belong to the `readonly` type.
 // XML, lists, mappings, tables, and objects are selectively immutable types, where values belonging to such types
-// are immutable and belong to the `readonly` type only if their read-only bit is set.
+// are immutable and belong to the `readonly` type only if they are constructed as immutable values (either by
+// using a subtype of `readonly` as the contextually expected type with a constructor expression or by calling
+// `.cloneReadOnly()` on a mutable value).
 // A `readonly` value is deeply immutable, and guarantees that members, if any, are also immutable.

--- a/examples/readonly-type/readonly_type.description
+++ b/examples/readonly-type/readonly_type.description
@@ -2,8 +2,8 @@
 // `()`, `boolean`, `int`, `float`, `decimal`, `string`, `error`, `function`, `service`, and `typedesc` are
 // considered to be inherently immutable basic types, and a value belonging to an inherently immutable basic type
 // will always belong to the `readonly` type.
-// XML, lists, mappings, tables, and objects are selectively immutable types, where values belonging to such types
-// are immutable and belong to the `readonly` type only if they are constructed as immutable values (either by
-// using a subtype of `readonly` as the contextually expected type with a constructor expression or by calling
+// XML, lists, mappings, tables, and objects are selectively-immutable types, where values belonging to such types
+// are immutable and belong to the `readonly` type, only if they are constructed as immutable values (either by
+// using a subtype of `readonly` as the contextually-expected type with a constructor expression or by calling
 // `.cloneReadOnly()` on a mutable value).
 // A `readonly` value is deeply immutable, and guarantees that members, if any, are also immutable.

--- a/examples/type-test-expression/type_test_expression.bal
+++ b/examples/type-test-expression/type_test_expression.bal
@@ -17,7 +17,8 @@ public function main() {
                     message);
     }
 
-    // The type test can be used to find the runtime type of union type variables.
+    // The type test can be used to find the type of a value held by a
+    // union-typed variable.
     Student alex = { name: "Alex" };
     Student|Person|Vehicle entity = alex;
 
@@ -36,7 +37,7 @@ public function main() {
         io:println("entity is not a person");
     }
 
-    // Type of `entity` is Student. However, it is not structurally equivalent to `Vehicle`.
+    // Type of `entity` is Student. It is not structurally equivalent to `Vehicle`.
     if (entity is Vehicle) {
         io:println("entity is a vehicle");
     } else {


### PR DESCRIPTION
## Purpose
This PR
- removes the invalid terms related to integer ranges from the `foreach` BBE
- improves the `readonly` BBE description to avoid mentioning the "read-only bit" - fixes https://github.com/ballerina-platform/ballerina-distribution/issues/629
- improves the type test BBE comments

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes