### PR TITLE
Exclude SLF4J bindings when copying libs

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -216,6 +216,8 @@ task copyOtherRepos(type: Copy) {
         def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
         into("bre/lib/") {
             from "${artifactExtractedPath}/libs"
+            exclude "slf4j-jdk14-1.7.26.jar"
+            exclude "slf4j-api-1.7.26.jar"
         }
         into("docs/") {
             from "${artifactExtractedPath}/docs"
@@ -307,10 +309,14 @@ task packageDist(type: Zip) {
     }
     into("${parentDir}/bre/lib") {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/bre/lib") {
         from "build/target/extracted-distributions/azurefunctions-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/bre/lib") {
@@ -388,10 +394,14 @@ task packageDistZip(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/azurefunctions-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
@@ -502,10 +512,14 @@ task packageDistLinux(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/azurefunctions-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
@@ -612,10 +626,14 @@ task packageDistMac(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/azurefunctions-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
@@ -717,10 +735,14 @@ task packageDistWindows(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/awslambda-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
         from "build/target/extracted-distributions/azurefunctions-extension-balo-zip/libs"
+        exclude "slf4j-jdk14-1.7.26.jar"
+        exclude "slf4j-api-1.7.26.jar"
         fileMode = 0644
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {


### PR DESCRIPTION
## Purpose
This PR excludes any additional SLF4J bindings that may get added by the C2C artifacts when copying them to `bre/lib`. Note that this is a temporary solution to get the release fixed ASAP.

