### PR TITLE
Improve build actions

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
+        run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon --continue
       - name: Notify failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: distribtuions
-          path: ballerina/build/distributions/*.zip
+          path: ballerina/build/distributions/ballerina-swan-lake-*.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
+        run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon --continue
       - name: Archive distribtuions
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,25 @@ jobs:
       - name: Archive distribtuions
         uses: actions/upload-artifact@v2
         with:
-          name: distribtuions
+          name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-swan-lake-*.zip
+      - name: Archive distribtuions
+        uses: actions/upload-artifact@v2
+        with:
+          name: Ballerina ZIP with short name
+          path: ballerina/build/distributions/ballerina-sl*.zip
+      - name: Archive distribtuions
+        uses: actions/upload-artifact@v2
+        with:
+          name: Linux installer ZIP
+          path: ballerina/build/distributions/ballerina-linux-*.zip
+      - name: Archive distribtuions
+        uses: actions/upload-artifact@v2
+        with:
+          name: MacOS installer ZIP
+          path: ballerina/build/distributions/ballerina-macos-*.zip
+      - name: Archive distribtuions
+        uses: actions/upload-artifact@v2
+        with:
+          name: Windows Installer ZIP
+          path: ballerina/build/distributions/ballerina-windows-*.zip

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
+        run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon --continue


### PR DESCRIPTION
## Purpose
1. Mark on the zip distribution as upload artefact
2. Continue build even if there is a task failure. This is so that we don't have to wait and fix tests sequentially,