### PR TITLE
Convert AWS Lambda artifacts to GitHub packages

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -263,14 +263,6 @@ task packageDist(type: Zip) {
     }
     // Code2Cloud Extensions
     into("${parentDir}/examples") {
-        from "build/target/extracted-distributions/awslambda-extension-examples-zip"
-        exclude "index.js"
-    }
-    into("${parentDir}/examples") {
-        from "build/target/extracted-distributions/azurefunctions-extension-examples-zip"
-        exclude "index.js"
-    }
-    into("${parentDir}/examples") {
         from "build/target/extracted-distributions/docker-extension-examples-zip"
         exclude "index.js"
     }
@@ -281,14 +273,8 @@ task packageDist(type: Zip) {
     into("${parentDir}/repo/cache/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/cache"
     }
-    into("${parentDir}/repo/cache") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/cache"
-    }
     into("${parentDir}/repo/balo/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/balo/"
-    }
-    into("${parentDir}/repo/balo/") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/balo/"
     }
 
     /* Files */
@@ -326,10 +312,6 @@ task packageDistZip(type: Zip) {
     }
     // Code2Cloud Extensions
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
-        from "build/target/extracted-distributions/awslambda-extension-examples-zip"
-        exclude "index.js"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
         from "build/target/extracted-distributions/docker-extension-examples-zip"
         exclude "index.js"
     }
@@ -340,14 +322,8 @@ task packageDistZip(type: Zip) {
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/cache"
     }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/cache"
-    }
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/balo/"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/balo/"
     }
 
     /* Tools artifacts */
@@ -418,10 +394,6 @@ task packageDistLinux(type: Zip) {
     }
     // Code2Cloud Extensions
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
-        from "build/target/extracted-distributions/awslambda-extension-examples-zip"
-        exclude "index.js"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
         from "build/target/extracted-distributions/docker-extension-examples-zip"
         exclude "index.js"
     }
@@ -432,14 +404,8 @@ task packageDistLinux(type: Zip) {
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/cache"
     }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/cache"
-    }
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/balo/"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/balo/"
     }
 
     /* Tools artifacts */
@@ -506,10 +472,6 @@ task packageDistMac(type: Zip) {
 
     // Code2Cloud Extensions
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
-        from "build/target/extracted-distributions/awslambda-extension-examples-zip"
-        exclude "index.js"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
         from "build/target/extracted-distributions/docker-extension-examples-zip"
         exclude "index.js"
     }
@@ -520,14 +482,8 @@ task packageDistMac(type: Zip) {
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/cache"
     }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/cache"
-    }
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/balo/"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/balo/"
     }
 
     /* Tools artifacts */
@@ -589,10 +545,6 @@ task packageDistWindows(type: Zip) {
 
     // Code2Cloud Extensions
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
-        from "build/target/extracted-distributions/awslambda-extension-examples-zip"
-        exclude "index.js"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
         from "build/target/extracted-distributions/docker-extension-examples-zip"
         exclude "index.js"
     }
@@ -603,14 +555,8 @@ task packageDistWindows(type: Zip) {
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/cache"
     }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/cache") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/cache"
-    }
     into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
         from "build/target/extracted-distributions/docker-extension-annotations-zip/balo/"
-    }
-    into("${parentDir}/distributions/ballerina-${shortVersion}/repo/balo/") {
-        from "build/target/extracted-distributions/awslambda-extension-balo-zip/balo/"
     }
 
     /* Tools artifacts */

--- a/build.gradle
+++ b/build.gradle
@@ -410,8 +410,6 @@ subprojects {
         maven { url "https://maven.wso2.org/nexus/content/repositories/orgballerinalang-1614/" }
         /* Docker staging repository */
         maven { url "https://maven.wso2.org/nexus/content/repositories/orgballerinaxdocker-1293/" }
-        /* AwsLambda staging repository */
-        maven { url "https://maven.wso2.org/nexus/content/repositories/orgballerinaxawslambda-1166/" }
         /* Datamapper staging repository */
         maven { url "https://maven.wso2.org/nexus/content/repositories/orgballerinaxdatamapper-1010/" }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -383,6 +383,7 @@ subprojects {
             }
         }
 
+        /* Code2Cloud extension repos */
         maven {
             url "https://maven.pkg.github.com/ballerina-platform/module-ballerina-c2c"
             credentials {
@@ -390,9 +391,15 @@ subprojects {
                 password System.getenv("packagePAT")
             }
         }
-
         maven {
             url "https://maven.pkg.github.com/ballerina-platform/module-ballerinax-azure.functions"
+            credentials {
+                username System.getenv("packageUser")
+                password System.getenv("packagePAT")
+            }
+        }
+        maven {
+            url "https://maven.pkg.github.com/ballerina-platform/module-ballerinax-aws.lambda"
             credentials {
                 username System.getenv("packageUser")
                 password System.getenv("packagePAT")
@@ -439,11 +446,6 @@ subprojects {
 
         /* Ballerina Dev Tools */
         devTools "org.ballerinalang:ballerina-dev-tools:${devToolsVersion}"
-
-        /* AWSLambda extension */
-        exten "org.ballerinax.awslambda:awslambda-extension:${awslambdaVersion}"
-        awsLambdaBalo "org.ballerinax.awslambda:awslambda-extension-balo:${awslambdaVersion}"
-        awsLambdaExamples "org.ballerinax.awslambda:awslambda-extension-examples:${awslambdaVersion}@zip"
 
         /* Docker extension */
         exten "org.ballerinax.docker:docker-extension:${dockerVersion}@jar"
@@ -494,9 +496,11 @@ subprojects {
 
         ballerinaC2cLibs "io.ballerina:c2c-ballerina:${c2cVersion}"
         ballerinaC2cLibs "org.ballerinax.azurefunctions:azurefunctions-extension-balo:${azFunctionsVersion}"
+        ballerinaC2cLibs "org.ballerinax.awslambda:awslambda-extension-balo:${awslambdaVersion}"
 
         ballerinaC2cExamples "io.ballerina:c2c-extension-examples:${c2cVersion}@zip"
         ballerinaC2cExamples "org.ballerinax.azurefunctions:azurefunctions-extension-examples:${azFunctionsVersion}@zip"
+        ballerinaC2cExamples "org.ballerinax.awslambda:awslambda-extension-examples:${awslambdaVersion}@zip"
 
         balCommand "org.ballerinalang:ballerina-command-distribution:${ballerinaCommandVersion}@zip"
     }


### PR DESCRIPTION
## Purpose
- Convert AWS Lambda artifacts to GitHub packages
- Resolves https://github.com/ballerina-platform/module-ballerinax-aws.lambda/issues/234