### PR TITLE
Migrate tests to grade test task

### DIFF
--- a/ballerina-test/build.gradle
+++ b/ballerina-test/build.gradle
@@ -37,26 +37,28 @@ dependencies {
     ballerinaWindowsDistribution project(path: ":ballerina", configuration: "ballerinaWindowsDistribution")
 }
 
-test {
+task distributionTest {
     dependsOn configurations.jBallerinaDistribution
     dependsOn configurations.ballerinaDistribution
     dependsOn configurations.ballerinaLinuxDistribution
     dependsOn configurations.ballerinaLinuxDistribution
     dependsOn configurations.ballerinaWindowsDistribution
-    systemProperty "distributions.dir", "$buildDir/../../ballerina/build/distributions"
-    systemProperty "target.dir", "$buildDir"
-    systemProperty "maven.version", "$version"
-    systemProperty "examples.dir", "$buildDir/../../examples"
-    systemProperty "line.check.extensions", ".java, .bal"
-    systemProperty "short.version", "$shortVersion"
+    test {
+        systemProperty "distributions.dir", "$buildDir/../../ballerina/build/distributions"
+        systemProperty "target.dir", "$buildDir"
+        systemProperty "maven.version", "$version"
+        systemProperty "examples.dir", "$buildDir/../../examples"
+        systemProperty "line.check.extensions", ".java, .bal"
+        systemProperty "short.version", "$shortVersion"
 
-    useTestNG() {
-        suites 'src/test/resources/testng.xml'
-        suites 'src/test/resources/testing-line-length.xml'
-    }
-    testLogging {
-        showStandardStreams = true
+        useTestNG() {
+            suites 'src/test/resources/testng.xml'
+            suites 'src/test/resources/testing-line-length.xml'
+        }
+        testLogging {
+            showStandardStreams = true
+        }
     }
 }
 
-build.dependsOn test
+test.dependsOn distributionTest

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -1342,4 +1342,6 @@ deleteTemporaryFiles.dependsOn packageDistWindows
 deleteTemporaryFiles.dependsOn testExamples
 deleteTemporaryFiles.dependsOn testStdlibs
 deleteTemporaryFiles.dependsOn testDevToolsIntegration
-build.dependsOn deleteTemporaryFiles
+test.dependsOn deleteTemporaryFiles
+test.dependsOn testExamples
+test.dependsOn testStdlibs

--- a/devtools-integration-tests/build.gradle
+++ b/devtools-integration-tests/build.gradle
@@ -37,25 +37,27 @@ dependencies {
     ballerinaWindowsDistribution project(path: ":ballerina", configuration: "ballerinaWindowsDistribution")
 }
 
-test {
+task devToolsIntegrationTest {
     dependsOn configurations.jBallerinaDistribution
     dependsOn configurations.ballerinaDistribution
     dependsOn configurations.ballerinaLinuxDistribution
     dependsOn configurations.ballerinaLinuxDistribution
     dependsOn configurations.ballerinaWindowsDistribution
-    systemProperty "distributions.dir", "$buildDir/../../ballerina/build/distributions"
-    systemProperty "target.dir", "$buildDir"
-    systemProperty "maven.version", "$version"
-    systemProperty "examples.dir", "$buildDir/../../examples"
-    systemProperty "line.check.extensions", ".java, .bal"
-    systemProperty "short.version", "$shortVersion"
+    test {
+        systemProperty "distributions.dir", "$buildDir/../../ballerina/build/distributions"
+        systemProperty "target.dir", "$buildDir"
+        systemProperty "maven.version", "$version"
+        systemProperty "examples.dir", "$buildDir/../../examples"
+        systemProperty "line.check.extensions", ".java, .bal"
+        systemProperty "short.version", "$shortVersion"
 
-    useTestNG() {
-        suites 'src/test/resources/testng.xml'
-    }
-    testLogging {
-        showStandardStreams = true
+        useTestNG() {
+            suites 'src/test/resources/testng.xml'
+        }
+        testLogging {
+            showStandardStreams = true
+        }
     }
 }
 
-build.dependsOn test
+test.dependsOn devToolsIntegrationTest

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,8 @@ stdlibFileVersion=0.6.2-SNAPSHOT
 stdlibFtpVersion=1.0.3-SNAPSHOT
 stdlibMimeVersion=1.0.4-SNAPSHOT
 stdlibNatsVersion=1.0.6-SNAPSHOT
-stdlibStanVersion=1.0.0-SNAPSHOT
 stdlibRabbitmqVersion=1.0.6-SNAPSHOT
+stdlibStanVersion=1.0.0-SNAPSHOT
 stdlibTcpVersion=0.7.2-SNAPSHOT
 stdlibUdpVersion=0.8.0-SNAPSHOT
 
@@ -54,8 +54,8 @@ stdlibOAuth2Version=1.0.4-SNAPSHOT
 stdlibGraphqlVersion=0.1.0-SNAPSHOT
 stdlibGrpcVersion=0.7.4-SNAPSHOT
 stdlibSqlVersion=0.5.3-SNAPSHOT
-stdlibWebsubVersion=1.0.8-SNAPSHOT
 stdlibWebsocketVersion=1.0.4-SNAPSHOT
+stdlibWebsubVersion=1.0.8-SNAPSHOT
 
 # Stdlib Level 09
 stdlibJdbcVersion=0.5.3-SNAPSHOT


### PR DESCRIPTION
## Purpose

Currently, all the tests inside the `ballerina-distribution` are running even when we specify `-x test`. This is happening because all the tests are now a part of the Gradle `build` task, instead of the Gradle `test` task.

WIth this PR, all the testing tasks are added to the Gradle `test` task. 