### PR TITLE
Remove config api from http BBE

### DIFF
--- a/examples/https-listener/https_listener.bal
+++ b/examples/https-listener/https_listener.bal
@@ -1,4 +1,3 @@
-import ballerina/config;
 import ballerina/http;
 import ballerina/log;
 
@@ -9,8 +8,7 @@ import ballerina/log;
 http:ListenerConfiguration helloWorldEPConfig = {
     secureSocket: {
         keyStore: {
-            path: config:getAsString("b7a.home") +
-                  "/bre/security/ballerinaKeystore.p12",
+            path: "../resources/ballerinaKeystore.p12",
             password: "ballerina"
         }
     }

--- a/examples/https-listener/https_listener.server.out
+++ b/examples/https-listener/https_listener.server.out
@@ -1,4 +1,6 @@
 # To start the service, navigate to the directory that contains the
 # `.bal` file and execute the `bal run` command along with the Ballerina home path as a config.
-bal run https_listener.bal --b7a.home=<ballerina_home_path>
+# (You may need to change the keystore path, a sample keystore file is available in the distribution.
+# The file path is <ballerina.home>/examples/resources/ballerinaKeystore.p12)
+bal run https_listener.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9095


### PR DESCRIPTION
## Purpose
Remove config api from http BBE because config api is deprecated.
