### PR TITLE
Remove messaging modules from distribution 

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -693,7 +693,29 @@ task testExamples() {
             "ballerina-to-openapi",
             "log-api",
             "optional-type",
-            "while"
+            "while",
+
+            // Disabling since these modules are removed from the distribution
+            'kafka-consumer-client',
+            'kafka-producer',
+            'kafka-consumer-service',
+            'kafka-producer-transactional',
+            'kafka-consumer-group-service',
+            'kafka-authentication-sasl-plain-consumer',
+            'kafka-authentication-sasl-plain-producer',
+            'nats-basic-client',
+            'nats-streaming-client',
+            'nats-streaming-consumer-with-data-binding',
+            'nats-streaming-durable-subscriptions',
+            'nats-streaming-queue-group',
+            'nats-streaming-start-position',
+            'rabbitmq-producer',
+            'rabbitmq-consumer',
+            'rabbitmq-consumer-with-client-acknowledgement',
+            'rabbitmq-consumer-with-data-binding',
+            'rabbitmq-consumer-with-qos-settings',
+            'rabbitmq-transaction-producer',
+            'rabbitmq-transaction-consumer'
     ]
 
     // The following BBEs will be excluded from output verification, which means verifying the output of the `.bal` file
@@ -713,22 +735,9 @@ task testExamples() {
             'checkpanic', // Has user name in output
             'deprecation', // Contains user input
             'foreach', // Has tabs for formatting in input
-            'kafka-consumer-client',
-            'kafka-producer',
-            'kafka-consumer-service',
-            'kafka-producer-transactional',
-            'kafka-consumer-group-service',
-            'kafka-authentication-sasl-plain-consumer',
-            'kafka-authentication-sasl-plain-producer', // Kafka BBEs are ignored since a KafkaCluster is not present
             'websub-service-integration-sample',
             'websub-internal-hub-sample',
             'grpc-server-streaming',
-            'nats-basic-client',
-            'nats-streaming-client',
-            'nats-streaming-consumer-with-data-binding',
-            'nats-streaming-durable-subscriptions',
-            'nats-streaming-queue-group',
-            'nats-streaming-start-position',
             'http-compression',
             'http-redirects',
             'http-2-0-server-push',
@@ -749,13 +758,6 @@ task testExamples() {
             'websocket-failover',
             'websocket-proxy-server',
             'websocket-retry',
-            'rabbitmq-producer',
-            'rabbitmq-consumer',
-            'rabbitmq-consumer-with-client-acknowledgement',
-            'rabbitmq-consumer-with-data-binding',
-            'rabbitmq-consumer-with-qos-settings',
-            'rabbitmq-transaction-producer',
-            'rabbitmq-transaction-consumer',
             'random',  // Output varies
             'jdbc-complex-type-queries', // Consists date time in output
             'jdbc-batch-execute-operation', // Consists transaction server sart log
@@ -1306,98 +1308,6 @@ task stopLdapServer() {
     }
 }
 
-//task startRabbitmqServer() {
-//    doLast {
-//        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-//            def stdOut = new ByteArrayOutputStream()
-//            exec {
-//                commandLine 'sh', '-c', "docker ps --filter name=my-rabbit"
-//                standardOutput = stdOut
-//            }
-//            if (!stdOut.toString().contains("my-rabbit")) {
-//                println "Starting RabbitMQ server."
-//                exec {
-//                    commandLine 'sh', '-c', "docker run --rm -d --name my-rabbit -p 15672:15672 -p  5672:5672 rabbitmq:3-management"
-//                    standardOutput = stdOut
-//                }
-//                println stdOut.toString()
-//                sleep(5 * 1000)
-//            } else {
-//                println "RabbitMQ server is already started."
-//            }
-//        }
-//    }
-//}
-//
-//task stopRabbitmqServer() {
-//    doLast {
-//        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-//            def stdOut = new ByteArrayOutputStream()
-//            exec {
-//                commandLine 'sh', '-c', "docker ps --filter name=my-rabbit"
-//                standardOutput = stdOut
-//            }
-//            if (stdOut.toString().contains("my-rabbit")) {
-//                println "Stopping RabbitMQ server."
-//                exec {
-//                    commandLine 'sh', '-c', "docker stop my-rabbit"
-//                    standardOutput = stdOut
-//                }
-//                println stdOut.toString()
-//                sleep(5 * 1000)
-//            } else {
-//                println "RabbitMQ server is not started."
-//            }
-//        }
-//    }
-//}
-//
-//task startNatsServer() {
-//    doLast {
-//        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-//            def stdOut = new ByteArrayOutputStream()
-//            exec {
-//                commandLine 'sh', '-c', "docker ps --filter name=my-nats"
-//                standardOutput = stdOut
-//            }
-//            if (!stdOut.toString().contains("my-nats")) {
-//                println "Starting NATS Basic server."
-//                exec {
-//                    commandLine 'sh', '-c', "docker run --rm -d --name my-nats -p 4222:4222 nats:latest"
-//                    standardOutput = stdOut
-//                }
-//                println stdOut.toString()
-//                sleep(5 * 1000)
-//            } else {
-//                println "NATS Basic server is already started."
-//            }
-//        }
-//    }
-//}
-//
-//task stopNatsServer() {
-//    doLast {
-//        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-//            def stdOut = new ByteArrayOutputStream()
-//            exec {
-//                commandLine 'sh', '-c', "docker ps --filter name=my-nats"
-//                standardOutput = stdOut
-//            }
-//            if (stdOut.toString().contains("my-nats")) {
-//                println "Stopping NATS server."
-//                exec {
-//                    commandLine 'sh', '-c', "docker stop my-nats"
-//                    standardOutput = stdOut
-//                }
-//                println stdOut.toString()
-//                sleep(5 * 1000)
-//            } else {
-//                println "NATS server is not started."
-//            }
-//        }
-//    }
-//}
-
 /* Unpack Dependencies */
 unpackJballerinaTools.dependsOn unpackBallerinaJre
 unpackDevTools.dependsOn unpackJballerinaTools
@@ -1432,12 +1342,8 @@ unpackStdLibs.dependsOn unpackJballerinaTools
 testExamples.dependsOn packageDist
 
 testStdlibs.dependsOn startLdapServer
-//testStdlibs.dependsOn startRabbitmqServer
-//testStdlibs.dependsOn startNatsServer
 testStdlibs.dependsOn packageDist
 testStdlibs.finalizedBy stopLdapServer
-//testStdlibs.finalizedBy stopRabbitmqServer
-//testStdlibs.finalizedBy stopNatsServer
 
 testDevToolsIntegration.dependsOn packageDist
 

--- a/build.gradle
+++ b/build.gradle
@@ -219,13 +219,6 @@ subprojects {
             }
         }
         maven {
-            url "https://maven.pkg.github.com/ballerina-platform/module-ballerinax-kafka"
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-        maven {
             url "https://maven.pkg.github.com/ballerina-platform/module-ballerina-log"
             credentials {
                 username System.getenv("packageUser")
@@ -247,13 +240,6 @@ subprojects {
             }
         }
         maven {
-            url "https://maven.pkg.github.com/ballerina-platform/module-ballerinax-nats"
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-        maven {
             url "https://maven.pkg.github.com/ballerina-platform/module-ballerina-oauth2"
             credentials {
                 username System.getenv("packageUser")
@@ -262,13 +248,6 @@ subprojects {
         }
         maven {
             url "https://maven.pkg.github.com/ballerina-platform/module-ballerina-os"
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-        maven {
-            url "https://maven.pkg.github.com/ballerina-platform/module-ballerinax-rabbitmq"
             credentials {
                 username System.getenv("packageUser")
                 password System.getenv("packagePAT")
@@ -304,13 +283,6 @@ subprojects {
         }
         maven {
             url "https://maven.pkg.github.com/ballerina-platform/module-ballerina-sql"
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-        maven {
-            url "https://maven.pkg.github.com/ballerina-platform/module-ballerinax-stan"
             credentials {
                 username System.getenv("packageUser")
                 password System.getenv("packagePAT")
@@ -528,20 +500,16 @@ subprojects {
         ballerinaStdLibs "org.ballerinalang:java.jdbc-ballerina:${stdlibJdbcVersion}"
         ballerinaStdLibs "org.ballerinalang:jsonutils-ballerina:${stdlibJsonutilsVersion}"
         ballerinaStdLibs "org.ballerinalang:jwt-ballerina:${stdlibJwtVersion}"
-        ballerinaStdLibs "org.ballerinalang:kafka-ballerina:${stdlibKafkaVersion}"
         ballerinaStdLibs "org.ballerinalang:log-ballerina:${stdlibLogVersion}"
         ballerinaStdLibs "org.ballerinalang:mime-ballerina:${stdlibMimeVersion}"
         ballerinaStdLibs "org.ballerinalang:mysql-ballerina:${stdlibMysqlVersion}"
-        ballerinaStdLibs "org.ballerinalang:nats-ballerina:${stdlibNatsVersion}"
         ballerinaStdLibs "org.ballerinalang:oauth2-ballerina:${stdlibOAuth2Version}"
         ballerinaStdLibs "org.ballerinalang:os-ballerina:${stdlibOsVersion}"
-        ballerinaStdLibs "org.ballerinalang:rabbitmq-ballerina:${stdlibRabbitmqVersion}"
         ballerinaStdLibs "org.ballerinalang:random-ballerina:${stdlibRandomVersion}"
         ballerinaStdLibs "org.ballerinalang:reflect-ballerina:${stdlibReflectVersion}"
         ballerinaStdLibs "org.ballerinalang:regex-ballerina:${stdlibRegexVersion}"
         ballerinaStdLibs "org.ballerinalang:runtime-ballerina:${stdlibRuntimeVersion}"
         ballerinaStdLibs "org.ballerinalang:sql-ballerina:${stdlibSqlVersion}"
-        ballerinaStdLibs "org.ballerinalang:stan-ballerina:${stdlibStanVersion}"
         ballerinaStdLibs "org.ballerinalang:task-ballerina:${stdlibTaskVersion}"
         ballerinaStdLibs "org.ballerinalang:tcp-ballerina:${stdlibTcpVersion}"
         ballerinaStdLibs "org.ballerinalang:time-ballerina:${stdlibTimeVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,9 +35,7 @@ stdlibFileVersion=0.6.5-SNAPSHOT
 stdlibFtpVersion=1.0.6-SNAPSHOT
 stdlibJwtVersion=1.0.9-SNAPSHOT
 stdlibMimeVersion=1.0.7-SNAPSHOT
-stdlibNatsVersion=1.0.9-SNAPSHOT
 stdlibOAuth2Version=1.0.7-SNAPSHOT
-stdlibStanVersion=1.0.3-SNAPSHOT
 stdlibTcpVersion=0.7.5-SNAPSHOT
 stdlibUdpVersion=0.8.3-SNAPSHOT
 
@@ -54,8 +52,6 @@ stdlibWebsubVersion=1.1.2-SNAPSHOT
 stdlibWebsubhubVersion=0.1.2-SNAPSHOT
 
 # Stdlib Level 07
-stdlibKafkaVersion=2.0.6-SNAPSHOT
-stdlibRabbitmqVersion=1.0.9-SNAPSHOT
 stdlibSqlVersion=0.5.6-SNAPSHOT
 
 # Stdlib Level 08


### PR DESCRIPTION
## Purpose

- Remove messaging modules under `ballerinax` org from distribution.
- Removed modules: `ballerinax/stan`, `ballerinax/nats`, `ballerinax/kafka`, `ballerinax/rabbitmq`.
- Disable messaging examples from building against the distribution. 
 Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/861 

## Remarks:

**PRs enabling pushing the modules to central**
https://github.com/ballerina-platform/module-ballerinax-kafka/pull/83
https://github.com/ballerina-platform/module-ballerinax-rabbitmq/pull/71
https://github.com/ballerina-platform/module-ballerinax-stan/pull/18
https://github.com/ballerina-platform/module-ballerinax-nats/pull/75

