### PR TITLE
Fix the deprecated null return in I/O streams

### DIFF
--- a/examples/byte-io/byte_io.bal
+++ b/examples/byte-io/byte_io.bal
@@ -14,7 +14,7 @@ public function main() returns @tainted error? {
 
     // Read the file as a stream of blocks. The default block size is 4KB.
     // Here, the default size is overridden by the value 2KB.
-    stream<io:Block, io:Error?> blockStream = check
+    stream<io:Block, io:Error> blockStream = check
     io:fileReadBlocksAsStream(imagePath, 2048);
     // If the file reading was successful, then,
     // the content will be written to the given destination file using the given stream.

--- a/examples/csv-io/csv_io.bal
+++ b/examples/csv-io/csv_io.bal
@@ -17,7 +17,7 @@ public function main() returns @tainted error? {
     // Write the given content stream to a CSV file.
     check io:fileWriteCsvFromStream(csvFilePath2, csvContent.toStream());
     // If the write operation was successful, then, perform a read operation to read the CSV content as a stream.
-    stream<string[], io:Error?> csvStream = check
+    stream<string[], io:Error> csvStream = check
                                         io:fileReadCsvAsStream(csvFilePath2);
     // Loop through the stream and print the content.
     error? e = csvStream.forEach(function(string[] val) {

--- a/examples/text-io/text_io.bal
+++ b/examples/text-io/text_io.bal
@@ -24,7 +24,7 @@ public function main() returns @tainted error? {
     // Write the given stream of lines to a file.
     check io:fileWriteLinesFromStream(textFilePath3, lines.toStream());
     // If the write operation was successful, then, perform a read operation to read the lines as a stream.
-    stream<string, io:Error?> lineStream = check
+    stream<string, io:Error> lineStream = check
                                     io:fileReadLinesAsStream(textFilePath3);
     // Loop through the stream and print the content.
     error? e = lineStream.forEach(function(string val) {


### PR DESCRIPTION
Previously, I/O streams returned a stream error with a null, however, the recent changes return a stream without a null as below.
`stream<anydata, io:Error>`.

