### PR TITLE
Enable tests for basic auth file user store

### DIFF
--- a/stdlib-integration-tests/auth/tests/Config.toml
+++ b/stdlib-integration-tests/auth/tests/Config.toml
@@ -1,0 +1,9 @@
+[[auth.users]]
+username="alice"
+password="123"
+scopes=["Admin", "Developer"]
+
+[[auth.users]]
+username="bob"
+password="456"
+scopes=["Developer"]

--- a/stdlib-integration-tests/auth/tests/auth_test.bal
+++ b/stdlib-integration-tests/auth/tests/auth_test.bal
@@ -26,11 +26,12 @@ listener http:Listener authListener = new(25001, {
     }
 });
 
-// TODO: Improve with file user store tests once the configurable features supports for map data types.
-// https://github.com/ballerina-platform/ballerina-standard-library/issues/862
-
 @http:ServiceConfig {
     auth: [
+        {
+            fileUserStoreConfig: {},
+            scopes: ["Admin"]
+        },
         {
             ldapUserStoreConfig: {
                 domainName: "avix.lk",
@@ -64,7 +65,73 @@ service /foo on authListener {
 }
 
 @test:Config {}
-public function testAuthModule1() {
+public function testAuthModuleFileUserStore1() {
+    http:Client clientEP = checkpanic new("https://localhost:25001", {
+        secureSocket: {
+           trustStore: {
+               path: "tests/resources/keystore/ballerinaTruststore.p12",
+               password: "ballerina"
+           }
+        },
+        auth: {
+            username: "alice",
+            password: "123"
+        }
+    });
+    var response = clientEP->get("/foo/bar");
+    if (response is http:Response) {
+        assertOK(response);
+    } else {
+        test:assertFail(msg = "Test Failed!");
+    }
+}
+
+@test:Config {}
+public function testAuthModuleFileUserStore2() {
+    http:Client clientEP = checkpanic new("https://localhost:25001", {
+        secureSocket: {
+           trustStore: {
+               path: "tests/resources/keystore/ballerinaTruststore.p12",
+               password: "ballerina"
+           }
+        },
+        auth: {
+            username: "bob",
+            password: "456"
+        }
+    });
+    var response = clientEP->get("/foo/bar");
+    if (response is http:Response) {
+        assertForbidden(response);
+    } else {
+        test:assertFail(msg = "Test Failed!");
+    }
+}
+
+@test:Config {}
+public function testAuthModuleFileUserStore3() {
+    http:Client clientEP = checkpanic new("https://localhost:25001", {
+        secureSocket: {
+           trustStore: {
+               path: "tests/resources/keystore/ballerinaTruststore.p12",
+               password: "ballerina"
+           }
+        },
+        auth: {
+            username: "eve",
+            password: "789"
+        }
+    });
+    var response = clientEP->get("/foo/bar");
+    if (response is http:Response) {
+        assertUnauthorized(response);
+    } else {
+        test:assertFail(msg = "Test Failed!");
+    }
+}
+
+@test:Config {}
+public function testAuthModuleLdapUserStore1() {
     http:Client clientEP = checkpanic new("https://localhost:25001", {
         secureSocket: {
            trustStore: {
@@ -86,7 +153,7 @@ public function testAuthModule1() {
 }
 
 @test:Config {}
-public function testAuthModule2() {
+public function testAuthModuleLdapUserStore2() {
     http:Client clientEP = checkpanic new("https://localhost:25001", {
         secureSocket: {
            trustStore: {
@@ -108,7 +175,7 @@ public function testAuthModule2() {
 }
 
 @test:Config {}
-public function testAuthModule3() {
+public function testAuthModuleLdapUserStore3() {
     http:Client clientEP = checkpanic new("https://localhost:25001", {
         secureSocket: {
            trustStore: {


### PR DESCRIPTION
## Purpose
$subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/862

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584