### PR TITLE
Implement a new BBE for time standard library 

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -715,7 +715,10 @@ task testExamples() {
             'rabbitmq-consumer-with-data-binding',
             'rabbitmq-consumer-with-qos-settings',
             'rabbitmq-transaction-producer',
-            'rabbitmq-transaction-consumer'
+            'rabbitmq-transaction-consumer',
+            'mysql-complex-type-queries',
+            'jdbc-complex-type-queries'
+
     ]
 
     // The following BBEs will be excluded from output verification, which means verifying the output of the `.bal` file

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -782,7 +782,7 @@ task testExamples() {
             'directory-listener',
             'file', // Absolute path varies
             'filepath', // Depends on OS
-            'time',
+            'time', // Due to a current timestamp
             'locks', // Output is inconsistent between runs
             'crypto', // Output with line breaks cannot be compared
             'jwt-issue-validate', // Output depends on time

--- a/examples/any-type/any_type.bal
+++ b/examples/any-type/any_type.bal
@@ -20,7 +20,7 @@ function lookupInfo(string id) returns any {
     if id == "pi" {
         return float:PI;
     } else if id == "date" {
-        return time:currentTime().toString();
+        return time:utcToString(time:utcNow());
     } else if id == "bio" {
         return new Person("Jane", "Doe");
     }

--- a/examples/any-type/tests/any_type_test.bal
+++ b/examples/any-type/tests/any_type_test.bal
@@ -17,18 +17,18 @@ function toString(any|error val) returns string => val is error? val.toString() 
 
 @test:Mock {
     moduleName: "ballerina/time",
-    functionName: "currentTime"
+    functionName: "utcNow"
 }
-test:MockFunction mock_currentTime = new();
+test:MockFunction mock_utcNow = new();
 
-public function mockCurrentTime() returns time:Time {
-    return checkpanic time:createTime(2020, 1, 1, 0, 0, 0, 0, "America/Panama");
+public function mockUtcNow(int? p) returns time:Utc {
+    return checkpanic time:utcFromString("2020-12-03T10:15:30.00Z");
 }
 
 @test:Config {}
 function testFunc() {
     test:when(mock_printLn).call("mockPrint");
-    test:when(mock_currentTime).call("mockCurrentTime");
+    test:when(mock_utcNow).call("mockUtcNow");
 
     // Calling the main fuction with empty args array
     main();
@@ -36,6 +36,6 @@ function testFunc() {
     test:assertEquals(outputs[1], "First name: John");
     test:assertEquals(outputs[2], "[1,3,5,6]");
     test:assertEquals(outputs[3], "3.141592653589793");
-    test:assertEquals(outputs[4], "{\"time\":1577854800000,\"zone\":{\"id\":\"America/Panama\",\"offset\":-18000}}");
+    test:assertEquals(outputs[4], "2020-12-03T10:15:30Z");
     test:assertEquals(outputs[5], "Jane Doe");
 }

--- a/examples/time/tests/time_test.bal
+++ b/examples/time/tests/time_test.bal
@@ -25,9 +25,13 @@ function testFunc() returns error? {
 
     // Invoking the main function
     check main();
-    test:assertEquals(outputs[1], "Created Time: 2017-03-28T23:42:45.554-05:00");
-    test:assertEquals(outputs[2], "Parsed Time: 2017-06-26T09:46:22.444-05:00");
-    test:assertEquals(outputs[16], "Before converting the time zone: 2017-03-28T23:42:45.554-05:00");
-    test:assertEquals(outputs[17], "After converting the time zone: 2017-03-29T10:12:45.554+05:30");
-    test:assertEquals(outputs[18], "Difference between the two time values: {\"years\":1,\"months\":2,\"days\":1,\"hours\":1,\"minutes\":0,\"seconds\":0,\"milliSeconds\":0}");
+    test:assertEquals(outputs[3], "UTC value: 1196676930 0.0");
+    test:assertEquals(outputs[4], "UTC string representation: 2007-12-03T10:15:30Z");
+    test:assertEquals(outputs[6], "Is valid date: true");
+    test:assertEquals(outputs[7], "Day of week: 1");
+    test:assertEquals(outputs[8], "Civil record: {\"timeAbbrev\":\"Z\",\"year\":2007,\"month\":12,\"day\":3,\"hour\":10,\"minute\":15,\"second\":30}");
+    test:assertEquals(outputs[9], "UTC value of the civil record: 1618269650 0.52");
+    test:assertEquals(outputs[10], "Converted civil value: {\"utcOffset\":{\"hours\":5,\"minutes\":30},\"timeAbbrev\":\"Asia/Colombo\",\"year\":2021,\"month\":4,\"day\":12,\"hour\":23,\"minute\":20,\"second\":50.52}");
+    test:assertEquals(outputs[11], "Civil string representation: 2021-04-12T17:50:50.520Z");
+
 }

--- a/examples/time/time.bal
+++ b/examples/time/time.bal
@@ -2,79 +2,83 @@ import ballerina/io;
 import ballerina/time;
 
 public function main() returns error? {
-    // To create the `time:Time` object, use either the `currentTime()`,
-    // `createTime()`, or the `parse()` function.
-    // This fetches the current time.
-    time:Time time = time:currentTime();
-    int currentTimeMills = time.time;
-    io:println("Current system time in milliseconds: ", currentTimeMills);
-    // Specifies a time with the required year, month, date,
-    // time, and timezone information.
-    time:Time timeCreated = check time:createTime(2017, 3, 28, 23, 42, 45,
-        554, "America/Panama");
-    io:println("Created Time: ", time:toString(timeCreated));
-    // This retrieves the time for a given string representation
-    // based on the specified string format.
-    time:Time t1 = check time:parse("2017-06-26T09:46:22.444-0500",
-        "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    // Prints it as an ISO 8601 formatted string.
-    io:println("Parsed Time: ", time:toString(t1));
-    // This fetches the formatted string of a given time.
-    string customTimeString = check time:format(time, "yyyy-MM-dd-E");
-    io:println("Current system time in custom format: ", customTimeString);
-    // These functions retrieve information related to a time object.
-    // This fetches the year of a given time.
-    int year = check time:getYear(time);
-    io:println("Year: ", year);
-    // This fetches the month value of a given time.
-    int month = check time:getMonth(time);
-    io:println("Month: ", month);
-    // This fetches the day value of a given time.
-    int day = check time:getDay(time);
-    io:println("Day: ", day);
-    // This fetches the hour value of a given time.
-    int hour = check time:getHour(time);
-    io:println("Hour: ", hour);
-    // This fetches the minute value of a given time.
-    int minute = check time:getMinute(time);
-    io:println("Minute: ", minute);
-    // This fetches the seconds value of a given time.
-    int second = check time:getSecond(time);
-    io:println("Second: ", second);
-    // This fetches the millisecond value of a given time.
-    int milliSecond = check time:getMilliSecond(time);
-    io:println("Millisecond: ", milliSecond);
-    // This fetches the day of the week of a given time.
-    time:DayOfWeek weekday = check time:getWeekday(time);
-    io:println("Weekday: ", weekday);
-    // This fetches the date component of the time using a single function.
-    [year, month, day] = check time:getDate(time);
-    io:println("Date: ", year, ":", month, ":", day);
-    // This fetches the time component using a single function.
-    [hour, minute, second, milliSecond] = check time:getTime(time);
-    io:println("Time: ", hour, ":", minute, ":", second, ":", milliSecond);
-    // This adds a given duration to a time. This example adds
-    // one year, one month, and one second to the current time.
-    time:Duration duration = {
-        years: 1,
-        months: 1,
-        seconds: 1
+    // Get the current instant of the system clock(seconds from the epoch of
+    // 1970-01-01T00:00:00). The returned `time:Utc` value represents seconds
+    // from the epoch with nanoseconds precision.
+    // The `time:Utc` is a tuple with [int, decimal]. The first member of the
+    // tuple represents the number of seconds from the epoch. The second
+    // member represents the rest of the nanoseconds from the epoch as a
+    // fraction.
+    time:Utc currentUtc = time:utcNow();
+    io:println(string `Current timestamp seconds: ${currentUtc[0]}s`);
+    io:println(string `Current timestamp nanoseconds as a
+    fraction: ${currentUtc[1]}s`);
+
+    // Return seconds from some unspecified epoch. The returned `seconds` has
+    // the nanoseconds precision which represents using the fractional part.
+    time:Seconds seconds = time:monotonicNow();
+    io:println(string `Seconds from an unspecified epoch: ${seconds}s`);
+
+    // Returns a `time:Utc` from a given RFC 3339 timestamp
+    // (e.g. `2007-12-03T10:15:30.00Z`).
+    time:Utc utc1 = check time:utcFromString("2007-12-03T10:15:30.00Z");
+    io:println("UTC value: " + utc1.toString());
+
+    // Returns the string representation of RFC 3339 timestamp
+    // (e.g. `2007-12-03T10:15:30.00Z`) from a given `time:Utc`.
+    string utcString1 = time:utcToString(utc1);
+    io:println(string `UTC string representation: ${utcString1}`);
+
+    // Returns the difference of two `time:Utc` values as
+    // seconds(`time:Seconds`).
+    time:Seconds utcDiff = time:utcDiffSeconds(currentUtc, utc1);
+    io:println(string `UTC diff: ${utcDiff}`);
+
+    // Check the given `time:Date` value is valid or not.
+    time:Date date = {year: 1994, month: 11, day: 7};
+    boolean isValidDate = (time:dateValidate(date) is ())? true: false;
+    io:println(string `Is valid date: ${isValidDate}`);
+
+    // Return the day of week as a number starting from 0 to 6 inclusive.
+    // 0 - SUNDAY, 1 - MONDAY, 2 - TUESDAY, 3 - WEDNESDAY, 4 - THURSDAY,
+    // 5 - FRIDAY, 6 - SATURDAY
+    time:DayOfWeek dayOfWeek = time:dayOfWeek(date);
+    io:println("Day of week: " + dayOfWeek.toString());
+
+    // Converts a given `time:Utc` value to a `time:Civil` value.
+    time:Civil civil1 = time:utcToCivil(utc1);
+    io:println("Civil record: " + civil1.toString());
+
+    // Converts a given `time:Civil` value to a `time:Utc` value.
+    // Note that, since `time:Civil` is used to represent localized time,
+    // it is mandatory to have the `utcOffset` field to be specified in the
+    // given `time:Civil` value.
+    time:ZoneOffset zoneOffset = {
+        hours: 5,
+        minutes: 30,
+        seconds: <decimal>0.0
     };
-    time:Time tmAdd = check time:addDuration(time, duration);
-    io:println("After adding a duration: ", time:toString(tmAdd));
-    // This subtracts a given duration from a time. This example
-    // subtracts one year, one month, and one second from the current time.
-    time:Time tmSub = check time:subtractDuration(time, duration);
-    io:println("After subtracting a duration: ", time:toString(tmSub));
-    // This converts the time to a different timezone.
-    time:Time t2 = check time:createTime(2017, 3, 28, 23, 42, 45, 554,
-        "America/Panama");
-    io:println("Before converting the time zone: ", time:toString(t2));
-    time:Time t3 = check time:toTimeZone(t2, "Asia/Colombo");
-    io:println("After converting the time zone: ", time:toString(t3));
-    //This calculates the difference between two time values.
-    time:Time startTime = check time:createTime(2021, 5, 3, 10);
-    time:Time endTime = check time:createTime(2022, 7, 4, 11);
-    time:Duration delta = check time:getDifference(startTime, endTime);
-    io:println("Difference between the two time values: ", delta);
+    time:Civil civil2 = {
+        year: 2021,
+        month: 4,
+        day: 13,
+        hour: 4,
+        minute: 50,
+        second: 50.52,
+        timeAbbrev: "Asia/Colombo",
+        utcOffset: zoneOffset
+    };
+    time:Utc utc2 = check time:utcFromCivil(civil2);
+    io:println("UTC value of the civil record: " + utc2.toString());
+
+    // Converts a given RFC 3339 timestamp(e.g. `2007-12-03T10:15:30.00Z`)
+    // to `time:Civil`.
+    time:Civil civil3 = check
+    time:civilFromString("2021-04-12T23:20:50.520+05:30[Asia/Colombo]");
+    io:println("Converted civil value: " + civil3.toString());
+
+    // Converts a given `time:Civil` value to a RFC 3339
+    // timestamp(e.g. `2007-12-03T10:15:30.00Z`) formatted string.
+    string civilString = check time:civilToString(civil3);
+    io:println(string `Civil string representation: ${civilString}`);
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ stdlibJavaArraysVersion=0.10.0-alpha5-SNAPSHOT
 stdlibRandomVersion=0.10.0-alpha5-SNAPSHOT
 stdlibRegexVersion=0.7.0-alpha5-SNAPSHOT
 stdlibTaskVersion=1.2.0-alpha5-SNAPSHOT
-stdlibTimeVersion=1.1.0-alpha5-SNAPSHOT
+stdlibTimeVersion=2.0.0-alpha5-SNAPSHOT
 stdlibUrlVersion=1.1.0-alpha5-SNAPSHOT
 stdlibXmldataVersion=1.1.0-alpha5-SNAPSHOT
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1081

## Approach
- redesign and implement the time BBE
- modify time changes in any-type BBE
- temporarily disable the following BBEs until time changes added(https://github.com/ballerina-platform/ballerina-distribution/commit/9c0b5fafd02bdca0117d7dc83a7f04d8d709c0db)
    - mysql-complex-type-queries
    - jdbc-complex-type-queries

## Automation tests
 - Unit tests 
   > Yes

## Test environment
- macOS
- Java 11
- SLA 3