### PR TITLE
Replace 'readonly & Error err' with 'Error err' in udp and tcp modules

### DIFF
--- a/examples/tcp-listener/tcp_listener.bal
+++ b/examples/tcp-listener/tcp_listener.bal
@@ -24,7 +24,7 @@ service class EchoService {
 
     // This remote method is invoked in an error situation
     // if it happens during the `onConnect` and `onBytes` methods.
-    remote function onError(readonly & tcp:Error err) returns tcp:Error? {
+    remote function onError(tcp:Error err) returns tcp:Error? {
         log:printError("An error occurred", 'error = err);
     }
 

--- a/stdlib-integration-tests/tcp/tests/mock_servers.bal
+++ b/stdlib-integration-tests/tcp/tests/mock_servers.bal
@@ -44,7 +44,7 @@ service class EchoService {
         check caller->writeBytes(data);
     }
 
-    isolated remote function onError(readonly & tcp:Error err) returns tcp:Error? {
+    isolated remote function onError(tcp:Error err) returns tcp:Error? {
         io:println(err.message());
     }
 
@@ -103,7 +103,7 @@ service class SecureEchoService {
         return data;
     }
 
-    isolated remote function onError(readonly & tcp:Error err) returns tcp:Error? {
+    isolated remote function onError(tcp:Error err) returns tcp:Error? {
         io:println(err.message());
     }
 }

--- a/stdlib-integration-tests/udp/tests/mock_servers.bal
+++ b/stdlib-integration-tests/udp/tests/mock_servers.bal
@@ -42,7 +42,7 @@ service on new udp:Listener(PORT1) {
         }
     }
 
-    remote function onError(readonly & udp:Error err) {
+    remote function onError(udp:Error err) {
         log:printError("An error occurred", 'error = err);
     }
 }


### PR DESCRIPTION
## Purpose
> Replace 'readonly & Error err' with 'Error err' in udp and tcp modules