### PR TITLE
Fix "The Main Function" example

### DIFF
--- a/examples/the-main-function/tests/the_main_function_test.bal
+++ b/examples/the-main-function/tests/the_main_function_test.bal
@@ -34,7 +34,7 @@ function testFunc() {
 
     // Invoking the main function.
     counter = 0;
-    e = main("Alice", year="Sophomore");
+    e = main("Alice", 18, "Sophomore");
     test:assertTrue(e is ());
     test:assertExactEquals(outputs[0], "Name: Alice, Age: 18, Year: Sophomore");
 

--- a/examples/the-main-function/the_main_function.description
+++ b/examples/the-main-function/the_main_function.description
@@ -1,4 +1,11 @@
+
 // A `public` function named `main` is considered as an entry point to a Ballerina program.
-// The `main` function is data-binding and can have zero or more parameters whose types are subtypes of `anydata`,
+// The `main` function is data-binding and can have zero or more parameters whose types are
+// string, int, float, decimal or union of one of these types and nil.
 // including any number of required/defaultable parameters and/or a single rest parameter.
-// The `main` function could also return a value whose type is a subtype of `error?`.
+// The main parameters except for the last parameters if it is a *record, represents operands 
+// in the command line. The order of operands is significant.
+// The last parameter can be a *record that represents options in the command line.
+// The *record field types are same as that of the parameter types. 
+// The order of option command line arguments are insignificant. 
+// There can be required/defaultable parameters in the record.

--- a/examples/the-main-function/the_main_function.out
+++ b/examples/the-main-function/the_main_function.out
@@ -4,28 +4,28 @@
 # Use the ballerina `run` command to invoke the `main` function specifying `Alice`
 # as the string argument for `name`. `18` would be set as the value for
 # `age` and `Freshman` would be set as the value for `year`.
-bal run the_main_function.bal Alice
+bal run the_main_function.bal -- Alice
 Name: Alice, Age: 18, Year: Freshman
 
 # Use the ballerina `run` command to invoke the `main` function specifying `Alice`
 # as the string argument for `name` and `20` as the integer value for
-# `age`. Both arguments are specified as positional arguments.
-bal run the_main_function.bal Alice 20
+# `age`. Both arguments are specified as operands.
+bal run the_main_function.bal -- Alice 20
 Name: Alice, Age: 20, Year: Freshman
 
 # Use the ballerina `run` command to invoke the `main` function specifying `Alice`
-# as the string argument for `name` and `Sophomore` as the string argument for
-# `year`. The value for `year` is specified as a named argument.
-bal run the_main_function.bal Alice -year=Sophomore
+# as the string argument for `name`, 18 as the `age` and `Sophomore` as the string
+# argument for `year`.
+bal run the_main_function.bal -- Alice 18 Sophomore
 Name: Alice, Age: 18, Year: Sophomore
 
 # Use the ballerina `run` command to invoke the `main` function specifying values for
 # all parameters, including the rest parameter. All arguments are specified as
-# positional arguments.
-bal run the_main_function.bal Alice 20 Sophomore math physics
+# operands.
+bal run the_main_function.bal -- Alice 20 Sophomore math physics
 Name: Alice, Age: 20, Year: Sophomore, Module(s): ["math","physics"]
 
 # Use the ballerina `run` command to invoke the `main` function specifying an invalid 
 # string as the argument for `name`. The `error` returned would be printed.
-bal run the_main_function.bal Ali
+bal run the_main_function.bal -- Ali
 error: InvalidName {"message":"invalid length"}


### PR DESCRIPTION
## Purpose
> 

## Goals
> N/A

## Approach
> This was broken due to changes to the support of command line arguments. Now the example is modified to use command line options.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> This is a sample

## Related PRs
> N/A
## Migrations (if applicable)
> N/A

## Test environment
> N/A
## Learning
> N/A