### PR TITLE
Re-add record example for configurable

### DIFF
--- a/examples/configurable/Config.toml
+++ b/examples/configurable/Config.toml
@@ -3,6 +3,10 @@ port = 9090
 enableRemote = false
 maxPayload = 0.321
 
+[admin]
+username = "admin"
+password = "admin-password"
+
 [[users]]
 username = "John"
 password="abc123"

--- a/examples/configurable/configurable.bal
+++ b/examples/configurable/configurable.bal
@@ -25,6 +25,12 @@ configurable float maxPayload = 1.0;
 // is not provided for it at configuration.
 configurable string protocol = "http";
 
+// A `configurable` variable named `admin` of the `UserInfo & readonly`
+// record type is initialized.
+configurable UserInfo & readonly admin = {
+    username: "default",
+    password: "password"
+};
 // A `configurable` variable named `users` of the
 // `table<(UserInfo & readonly)> key(username)` table type is initialized.
 configurable UserTable & readonly users = table [{
@@ -38,5 +44,6 @@ public function main() {
     io:println("protocol: ", protocol);
     io:println("maximum payload (in MB): ", maxPayload);
     io:println("remote enabled: ", enableRemote);
+    io:println("admin details: ", admin);
     io:println("users: ", users);
 }

--- a/examples/configurable/configurable.description
+++ b/examples/configurable/configurable.description
@@ -39,4 +39,4 @@
 //
 // Currently, TOML-based configuration is supported for configurable variables of
 // types `int`, `float`, `boolean`, `string`, `decimal`, the arrays of the respective
-// types, and table.
+// types, record, and table.

--- a/examples/configurable/configurable.out
+++ b/examples/configurable/configurable.out
@@ -8,6 +8,10 @@
 # enableRemote = false
 # maxPayload = 0.321
 #
+# [admin]
+# username = "admin"
+# password = "admin-password"
+#
 # [[users]]
 # username = "John"
 # password="abc123"
@@ -25,6 +29,7 @@ port: 9090
 protocol: http
 maximum payload (in MB): 0.321
 remote enabled: false
+admin details: {"username":"admin","password":"admin-password"}
 users: [{"username":"John","password":"abc123"},{"username":"Bob","password":"cde456"}]
 
 # A similar configuration can be given via CLI parameters in the
@@ -36,4 +41,5 @@ port: 9091
 protocol: http
 maximum payload (in MB): 0.456
 remote enabled: false
+admin details: {"username":"default","password":"password"}
 users: [{"username":"default","password":"password"}]


### PR DESCRIPTION
## Purpose
$subject
The record example is re-added as the support for configurable records are not removed.

## Goals

## Approach


## User stories

## Release note

## Documentation

## Training

## Certification
N/A

## Marketing


## Automation tests
 - Unit tests 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
ubuntu 20.04, jdk 11.0.9 

## Learning
