### PR TITLE
Remove readonly return type-descriptor from onBytes(), onDatagram() methods

### DIFF
--- a/examples/tcp-transport-security/tcp_transport_security_listener.bal
+++ b/examples/tcp-transport-security/tcp_transport_security_listener.bal
@@ -32,7 +32,7 @@ service on new tcp:Listener(9090, secureSocket = listenerSecureSocket) {
 
 service class EchoService {
 
-    remote function onBytes(readonly & byte[] data) returns readonly & byte[] {
+    remote function onBytes(readonly & byte[] data) returns byte[] {
         io:println("Received: ", 'string:fromBytes(data));
         return data;
     }

--- a/stdlib-integration-tests/tcp/tests/mock_servers.bal
+++ b/stdlib-integration-tests/tcp/tests/mock_servers.bal
@@ -98,7 +98,7 @@ service on new tcp:Listener(PORT4, secureSocket = {
 
 service class SecureEchoService {
 
-    remote function onBytes(readonly & byte[] data) returns readonly & byte[] {
+    remote function onBytes(readonly & byte[] data) returns byte[] {
         io:println("Echo: ", 'string:fromBytes(data));
         return data;
     }

--- a/stdlib-integration-tests/udp/tests/mock_servers.bal
+++ b/stdlib-integration-tests/udp/tests/mock_servers.bal
@@ -27,7 +27,7 @@ map<string> QuestionBank = {
 service on new udp:Listener(PORT1) {
 
  remote function onDatagram(readonly & udp:Datagram datagram, udp:Caller caller ) 
-        returns udp:Error|readonly & udp:Datagram? {
+        returns udp:Error|udp:Datagram? {
             string|error request = string:fromBytes(datagram.data);
         if (request is string && QuestionBank.hasKey(request)) {
             udp:Datagram|error response = datagram.cloneWithType(udp:Datagram);


### PR DESCRIPTION
## Purpose
> Remove readonly return type-descriptor from onBytes(), onDatagram() methods in both UDP, TCP module