### PR TITLE
Update AWS Lambada version in tests

### DIFF
--- a/ballerina-test/src/test/java/org/ballerinalang/distribution/test/DistributionArtifactCheckTest.java
+++ b/ballerina-test/src/test/java/org/ballerinalang/distribution/test/DistributionArtifactCheckTest.java
@@ -78,7 +78,7 @@ public class DistributionArtifactCheckTest {
                 .resolve("cache")
                 .resolve("ballerinax")
                 .resolve("awslambda")
-                .resolve("0.0.0");
+                .resolve("1.0.0");
 
         Path breLibPath = TEST_DISTRIBUTION_PATH
                 .resolve(DIST_NAME)

--- a/ballerina-test/src/test/java/org/ballerinalang/distribution/test/PlatformDistributionArtifactCheckTest.java
+++ b/ballerina-test/src/test/java/org/ballerinalang/distribution/test/PlatformDistributionArtifactCheckTest.java
@@ -109,7 +109,7 @@ public class PlatformDistributionArtifactCheckTest {
                 .resolve("cache")
                 .resolve("ballerinax")
                 .resolve("awslambda")
-                .resolve("0.0.0");
+                .resolve("1.0.0");
 
         Path breLibPath = distributionsPath
                 .resolve(jballerinaFileName)


### PR DESCRIPTION
## Purpose
- Update AWS Lambada version
- Depends on https://github.com/ballerina-platform/module-ballerinax-aws.lambda/pull/341