### PR TITLE
Fix compilation errors on threads-and-strand

### DIFF
--- a/examples/async/async.bal
+++ b/examples/async/async.bal
@@ -20,7 +20,7 @@ public function main() returns error? {
     future<int> f4 = start calculate("9*8*7*6");
     future<int> f5 = start calculate("5*4*3*2*1");
     // Wait for all the given futures to complete. The result of the `wait` action can be assigned to a map or a record. 
-    record { int|error r1; int|error r2; } result2 = wait {r1: f4, r2: f5};
+    record { int r1; int r2; } result2 = check wait {r1: f4, r2: f5};
     io:println("9! = ", result2.r1 * result2.r2);
 }
 

--- a/examples/async/async.bal
+++ b/examples/async/async.bal
@@ -20,8 +20,8 @@ public function main() returns error? {
     future<int> f4 = start calculate("9*8*7*6");
     future<int> f5 = start calculate("5*4*3*2*1");
     // Wait for all the given futures to complete. The result of the `wait` action can be assigned to a map or a record. 
-    record { int r1; int r2; } result2 = check wait {r1: f4, r2: f5};
-    io:println("9! = ", result2.r1 * result2.r2);
+    record { int|error r1; int|error r2; } result2 = wait {r1: f4, r2: f5};
+    io:println("9! = ", check result2.r1 * check result2.r2);
 }
 
 function calculate(string expr) returns int {

--- a/examples/async/tests/async_test.bal
+++ b/examples/async/tests/async_test.bal
@@ -16,11 +16,11 @@ public function mockPrint(any|error... val) {
 function toString(any|error val) returns string => val is error? val.toString() : val.toString();
 
 @test:Config{}
-function testFunc() {
+function testFunc() returns error? {
     test:when(mock_printLn).call("mockPrint");
 
     // Invoke the main function.
-    main();
+    check main();
     test:assertEquals(outputs[0], "Seconds in an year = 31536000");
     test:assertEquals(outputs[1], "125*34 = 4250");
     test:assertEquals(outputs[2], "9! = 362880");

--- a/examples/threads-and-strands/threads_and_strands.bal
+++ b/examples/threads-and-strands/threads_and_strands.bal
@@ -12,7 +12,7 @@ public function case1() {
     // Here, the `wait` action causes the current strand to yield.
     // Once it yields, the Ballerina runtime executes the new strand.
     io:println("Before the wait action");
-    int result = wait f1;
+    int|error result = wait f1;
     io:println("After the wait action\n");
 }
 
@@ -25,7 +25,7 @@ public function case2() {
     future<int> f1 = @strand {thread: "any"} start multiply(1, 2);
 
     io:println("Before the wait action");
-    int result = wait f1;
+    int|error result = wait f1;
     io:println("After the wait action\n");
 }
 
@@ -36,7 +36,7 @@ public function case3() {
     future<int> f2 = @strand {thread: "any"} start multiply(4, 5);
 
     io:println("Before the wait action");
-    map<int> results = wait {f1, f2};
+    map<int|error> results = wait {f1, f2};
     io:println("After the wait action\n");
 }
 
@@ -48,7 +48,7 @@ public function case4() {
     future<int> f2 = start multiply(4, 5);
 
     io:println("Before the wait action");
-    map<int> results = wait {f1, f2};
+    map<int|error> results = wait {f1, f2};
     io:println("After the wait action\n");
 }
 
@@ -59,7 +59,7 @@ public function case5() {
     future<int> f2 = start multiply(4, 5);
 
     io:println("Before the wait action");
-    map<int> results = wait {f1, f2};
+    map<int|error> results = wait {f1, f2};
     io:println("After the wait action\n");
 }
 


### PR DESCRIPTION
## Purpose
> This was caused by the changes to the return values of wait expressions on a future.