### PR TITLE
Update instructions of security BBEs

### DIFF
--- a/examples/graphql-service-basic-auth-file-user-store/graphql_service_basic_auth_file_user_store.server.out
+++ b/examples/graphql-service-basic-auth-file-user-store/graphql_service_basic_auth_file_user_store.server.out
@@ -9,6 +9,6 @@ username="bob"
 password="password2"
 scopes=["scope2", "scope3"]' > Config.toml
 
-# (You may need to change the certificate file path and private key file path.)
+# You may need to change the certificate file path and private key file path.
 bal run graphql_service_basic_auth_file_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-basic-auth-file-user-store/graphql_service_basic_auth_file_user_store.server.out
+++ b/examples/graphql-service-basic-auth-file-user-store/graphql_service_basic_auth_file_user_store.server.out
@@ -1,7 +1,5 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
-# Ensure that the `Config.toml` file is populated correctly with the user
-# information.
+# As a prerequisite, ensure that the `Config.toml` file is populated correctly
+# with the user information.
 echo '[["ballerina.auth.users"]]
 username="alice"
 password="password1"
@@ -10,6 +8,7 @@ scopes=["scope1"]
 username="bob"
 password="password2"
 scopes=["scope2", "scope3"]' > Config.toml
+
 # (You may need to change the certificate file path and private key file path.)
 bal run graphql_service_basic_auth_file_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-basic-auth-ldap-user-store/graphql_service_basic_auth_ldap_user_store.server.out
+++ b/examples/graphql-service-basic-auth-ldap-user-store/graphql_service_basic_auth_ldap_user_store.server.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path and private key file path.)
 bal run graphql_service_basic_auth_ldap_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-basic-auth-ldap-user-store/graphql_service_basic_auth_ldap_user_store.server.out
+++ b/examples/graphql-service-basic-auth-ldap-user-store/graphql_service_basic_auth_ldap_user_store.server.out
@@ -1,3 +1,3 @@
-# (You may need to change the certificate file path and private key file path.)
+# You may need to change the certificate file path and private key file path.
 bal run graphql_service_basic_auth_ldap_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-jwt-auth/graphql_service_jwt_auth.server.out
+++ b/examples/graphql-service-jwt-auth/graphql_service_jwt_auth.server.out
@@ -1,4 +1,4 @@
-# (You may need to change the certificate file path, private key file path and
-# trusted certificate file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run graphql_service_jwt_auth.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-jwt-auth/graphql_service_jwt_auth.server.out
+++ b/examples/graphql-service-jwt-auth/graphql_service_jwt_auth.server.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path, private key file path and
 # trusted certificate file path.)
 bal run graphql_service_jwt_auth.bal

--- a/examples/graphql-service-mutual-ssl/graphql_service_mutual_ssl.out
+++ b/examples/graphql-service-mutual-ssl/graphql_service_mutual_ssl.out
@@ -1,2 +1,4 @@
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run graphql_service_mutual_ssl.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-mutual-ssl/graphql_service_mutual_ssl.out
+++ b/examples/graphql-service-mutual-ssl/graphql_service_mutual_ssl.out
@@ -1,6 +1,2 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
-# (You may need to change the certificate file path, private key file path, and
-# trusted certificate file path.)
 bal run graphql_service_mutual_ssl.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-oauth2/graphql_service_oauth2.server.out
+++ b/examples/graphql-service-oauth2/graphql_service_oauth2.server.out
@@ -1,4 +1,4 @@
-# (You may need to change the certificate file path, private key file path and
-# trusted certificate file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run graphql_service_oauth2.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-oauth2/graphql_service_oauth2.server.out
+++ b/examples/graphql-service-oauth2/graphql_service_oauth2.server.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path, private key file path and
 # trusted certificate file path.)
 bal run graphql_service_oauth2.bal

--- a/examples/graphql-service-ssl-tls/graphql_service_ssl_tls.out
+++ b/examples/graphql-service-ssl-tls/graphql_service_ssl_tls.out
@@ -1,3 +1,3 @@
-# (You may need to change the certificate file path and private key file path.)
+# You may need to change the certificate file path and private key file path.
 bal run graphql_service_ssl_tls.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/graphql-service-ssl-tls/graphql_service_ssl_tls.out
+++ b/examples/graphql-service-ssl-tls/graphql_service_ssl_tls.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path and private key file path.)
 bal run graphql_service_ssl_tls.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-client-basic-auth/http_client_basic_auth.out
+++ b/examples/http-client-basic-auth/http_client_basic_auth.out
@@ -1,6 +1,4 @@
-# Before testing this sample, first start a sample service secured with Basic Auth.
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
+# As a prerequisite, start a sample service secured with Basic Auth.
 # (You may need to change the trusted certificate file path.)
 bal run http_client_basic_auth.bal
 Hello, World!

--- a/examples/http-client-basic-auth/http_client_basic_auth.out
+++ b/examples/http-client-basic-auth/http_client_basic_auth.out
@@ -1,4 +1,4 @@
 # As a prerequisite, start a sample service secured with Basic Auth.
-# (You may need to change the trusted certificate file path.)
+# You may need to change the trusted certificate file path.
 bal run http_client_basic_auth.bal
 Hello, World!

--- a/examples/http-client-bearer-token-auth/http_client_bearer_token_auth.out
+++ b/examples/http-client-bearer-token-auth/http_client_bearer_token_auth.out
@@ -1,3 +1,4 @@
 # As a prerequisite, start a secured sample service.
+# You may need to change the trusted certificate file path.
 bal run http_client_bearer_token_auth.bal
 Hello, World!

--- a/examples/http-client-bearer-token-auth/http_client_bearer_token_auth.out
+++ b/examples/http-client-bearer-token-auth/http_client_bearer_token_auth.out
@@ -1,6 +1,3 @@
-# Before testing this sample, first start a secured sample service.
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
-# (You may need to change the trusted certificate file path.)
+# As a prerequisite, start a secured sample service.
 bal run http_client_bearer_token_auth.bal
 Hello, World!

--- a/examples/http-client-mutual-ssl/http_client_mutual_ssl.out
+++ b/examples/http-client-mutual-ssl/http_client_mutual_ssl.out
@@ -1,5 +1,5 @@
 # As a prerequisite, start a sample service secured with mutual SSL.
-# (You may need to change the certificate file path, private key file path and
-# trusted certificate file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run http_client_mutual_ssl.bal
 Hello, World!

--- a/examples/http-client-mutual-ssl/http_client_mutual_ssl.out
+++ b/examples/http-client-mutual-ssl/http_client_mutual_ssl.out
@@ -1,11 +1,4 @@
-# As a prerequisite, navigate to the directory that contains the
-# `http_service_mutual_ssl.bal` file and execute the `bal run` command below.
-# (You may need to change the certificate file path and private key file path.)
-bal run http_service_mutual_ssl.bal
-[ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090
-
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
+# As a prerequisite, start a sample service secured with mutual SSL.
 # (You may need to change the certificate file path, private key file path and
 # trusted certificate file path.)
 bal run http_client_mutual_ssl.bal

--- a/examples/http-client-oauth2-client-credentials-grant-type/http_client_oauth2_client_credentials_grant_type.out
+++ b/examples/http-client-oauth2-client-credentials-grant-type/http_client_oauth2_client_credentials_grant_type.out
@@ -1,6 +1,4 @@
-# Before testing this sample, first start a sample service secured with OAuth2.
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
+# As a prerequisite, start a sample service secured with OAuth2.
 # (You may need to change the trusted certificate file path.)
 bal run http_client_oauth2_client_credentials_grant_type.bal
 Hello, World!

--- a/examples/http-client-oauth2-client-credentials-grant-type/http_client_oauth2_client_credentials_grant_type.out
+++ b/examples/http-client-oauth2-client-credentials-grant-type/http_client_oauth2_client_credentials_grant_type.out
@@ -1,4 +1,4 @@
 # As a prerequisite, start a sample service secured with OAuth2.
-# (You may need to change the trusted certificate file path.)
+# You may need to change the trusted certificate file path.
 bal run http_client_oauth2_client_credentials_grant_type.bal
 Hello, World!

--- a/examples/http-client-oauth2-password-grant-type/http_client_oauth2_password_grant_type.out
+++ b/examples/http-client-oauth2-password-grant-type/http_client_oauth2_password_grant_type.out
@@ -1,4 +1,4 @@
 # As a prerequisite, start a sample service secured with OAuth2.
-# (You may need to change the trusted certificate file path.)
+# You may need to change the trusted certificate file path.
 bal run http_client_oauth2_password_grant_type.bal
 Hello, World!

--- a/examples/http-client-oauth2-password-grant-type/http_client_oauth2_password_grant_type.out
+++ b/examples/http-client-oauth2-password-grant-type/http_client_oauth2_password_grant_type.out
@@ -1,6 +1,4 @@
-# Before testing this sample, first start a sample service secured with OAuth2.
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
+# As a prerequisite, start a sample service secured with OAuth2.
 # (You may need to change the trusted certificate file path.)
 bal run http_client_oauth2_password_grant_type.bal
 Hello, World!

--- a/examples/http-client-oauth2-refresh-token-grant-type/http_client_oauth2_refresh_token_grant_type.out
+++ b/examples/http-client-oauth2-refresh-token-grant-type/http_client_oauth2_refresh_token_grant_type.out
@@ -1,4 +1,4 @@
 # As a prerequisite, start a sample service secured with OAuth2.
-# (You may need to change the trusted certificate file path.)
+# You may need to change the trusted certificate file path.
 bal run http_client_oauth2_refresh_token_grant_type.bal
 Hello, World!

--- a/examples/http-client-oauth2-refresh-token-grant-type/http_client_oauth2_refresh_token_grant_type.out
+++ b/examples/http-client-oauth2-refresh-token-grant-type/http_client_oauth2_refresh_token_grant_type.out
@@ -1,6 +1,4 @@
-# Before test this sample, first start a sample service secured with OAuth2.
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
+# As a prerequisite, start a sample service secured with OAuth2.
 # (You may need to change the trusted certificate file path.)
 bal run http_client_oauth2_refresh_token_grant_type.bal
 Hello, World!

--- a/examples/http-client-self-signed-jwt-auth/http_client_self_signed_jwt_auth.out
+++ b/examples/http-client-self-signed-jwt-auth/http_client_self_signed_jwt_auth.out
@@ -1,6 +1,4 @@
-# Before testing this sample, first start a sample service secured with JWT Auth.
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
+# As a prerequisite, start a sample service secured with OAuth2.
 # (You may need to change the trusted certificate file path and private key file path.)
 bal run http_client_self_signed_jwt_auth.bal
 Hello, World!

--- a/examples/http-client-self-signed-jwt-auth/http_client_self_signed_jwt_auth.out
+++ b/examples/http-client-self-signed-jwt-auth/http_client_self_signed_jwt_auth.out
@@ -1,4 +1,4 @@
 # As a prerequisite, start a sample service secured with OAuth2.
-# (You may need to change the trusted certificate file path and private key file path.)
+# You may need to change the trusted certificate file path and private key file path.
 bal run http_client_self_signed_jwt_auth.bal
 Hello, World!

--- a/examples/http-client-ssl-tls/http_client_ssl_tls.out
+++ b/examples/http-client-ssl-tls/http_client_ssl_tls.out
@@ -1,11 +1,4 @@
-# As a prerequisite, navigate to the directory that contains the
-# `http_service_ssl_tls.bal` file and execute the `bal run` command below.
-# (You may need to change the certificate file path and private key file path.)
-bal run http_service_ssl_tls.bal
-[ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090
-
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
+# As a prerequisite, start a sample service secured with SSL.
 # (You may need to change the trusted certificate file path.)
 bal run http_client_ssl_tls.bal
 Hello, World!

--- a/examples/http-client-ssl-tls/http_client_ssl_tls.out
+++ b/examples/http-client-ssl-tls/http_client_ssl_tls.out
@@ -1,4 +1,4 @@
 # As a prerequisite, start a sample service secured with SSL.
-# (You may need to change the trusted certificate file path.)
+# You may need to change the trusted certificate file path.
 bal run http_client_ssl_tls.bal
 Hello, World!

--- a/examples/http-service-basic-auth-file-user-store/http_service_basic_auth_file_user_store.server.out
+++ b/examples/http-service-basic-auth-file-user-store/http_service_basic_auth_file_user_store.server.out
@@ -9,6 +9,6 @@ username="bob"
 password="password2"
 scopes=["scope2", "scope3"]' > Config.toml
 
-# (You may need to change the certificate file path and private key file path.)
+# You may need to change the certificate file path and private key file path.
 bal run http_service_basic_auth_file_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-basic-auth-file-user-store/http_service_basic_auth_file_user_store.server.out
+++ b/examples/http-service-basic-auth-file-user-store/http_service_basic_auth_file_user_store.server.out
@@ -1,7 +1,5 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
-# Ensure that the `Config.toml` file is populated correctly with the user
-# information.
+# As a prerequisite, ensure that the `Config.toml` file is populated correctly
+# with the user information.
 echo '[["ballerina.auth.users"]]
 username="alice"
 password="password1"
@@ -10,6 +8,7 @@ scopes=["scope1"]
 username="bob"
 password="password2"
 scopes=["scope2", "scope3"]' > Config.toml
+
 # (You may need to change the certificate file path and private key file path.)
 bal run http_service_basic_auth_file_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-basic-auth-ldap-user-store/http_service_basic_auth_ldap_user_store.server.out
+++ b/examples/http-service-basic-auth-ldap-user-store/http_service_basic_auth_ldap_user_store.server.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path and private key file path.)
 bal run http_service_basic_auth_ldap_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-basic-auth-ldap-user-store/http_service_basic_auth_ldap_user_store.server.out
+++ b/examples/http-service-basic-auth-ldap-user-store/http_service_basic_auth_ldap_user_store.server.out
@@ -1,3 +1,3 @@
-# (You may need to change the certificate file path and private key file path.)
+# You may need to change the certificate file path and private key file path.
 bal run http_service_basic_auth_ldap_user_store.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-jwt-auth/http_service_jwt_auth.server.out
+++ b/examples/http-service-jwt-auth/http_service_jwt_auth.server.out
@@ -1,4 +1,4 @@
-# (You may need to change the certificate file path, private key file path and
-# trusted certificate file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run http_service_jwt_auth.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-jwt-auth/http_service_jwt_auth.server.out
+++ b/examples/http-service-jwt-auth/http_service_jwt_auth.server.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path, private key file path and
 # trusted certificate file path.)
 bal run http_service_jwt_auth.bal

--- a/examples/http-service-mutual-ssl/http_service_mutual_ssl.out
+++ b/examples/http-service-mutual-ssl/http_service_mutual_ssl.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path, private key file path, and
 # trusted certificate file path.)
 bal run http_service_mutual_ssl.bal

--- a/examples/http-service-mutual-ssl/http_service_mutual_ssl.out
+++ b/examples/http-service-mutual-ssl/http_service_mutual_ssl.out
@@ -1,4 +1,4 @@
-# (You may need to change the certificate file path, private key file path, and
-# trusted certificate file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run http_service_mutual_ssl.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-oauth2/http_service_oauth2.server.out
+++ b/examples/http-service-oauth2/http_service_oauth2.server.out
@@ -1,4 +1,4 @@
-# (You may need to change the certificate file path, private key file path and
-# trusted certificate file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run http_service_oauth2.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-oauth2/http_service_oauth2.server.out
+++ b/examples/http-service-oauth2/http_service_oauth2.server.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path, private key file path and
 # trusted certificate file path.)
 bal run http_service_oauth2.bal

--- a/examples/http-service-ssl-tls/http_service_ssl_tls.out
+++ b/examples/http-service-ssl-tls/http_service_ssl_tls.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path and private key file path.)
 bal run http_service_ssl_tls.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/http-service-ssl-tls/http_service_ssl_tls.out
+++ b/examples/http-service-ssl-tls/http_service_ssl_tls.out
@@ -1,3 +1,3 @@
-# (You may need to change the certificate file path and private key file path.)
+# You may need to change the certificate file path and private key file path.
 bal run http_service_ssl_tls.bal
 [ballerina/http] started HTTPS/WSS listener 0.0.0.0:9090

--- a/examples/security-crypto/security_crypto.out
+++ b/examples/security-crypto/security_crypto.out
@@ -1,5 +1,5 @@
-# (You may need to change the certificate file path, private key file path and
-keystore/truststore file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run security_crypto.bal
 Hex encoded hash with MD5: 0605402ee16d8e96511a58ff105bc24a
 Base64 encoded hash with SHA1: /8fwbGIevBvv2Nl3gEL9DtWas+Q=

--- a/examples/security-crypto/security_crypto.out
+++ b/examples/security-crypto/security_crypto.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path, private key file path and
 keystore/truststore file path.)
 bal run security_crypto.bal

--- a/examples/security-jwt-issue-validate/security_jwt_issue_validate.out
+++ b/examples/security-jwt-issue-validate/security_jwt_issue_validate.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 # (You may need to change the certificate file path, trusted certificate file
 # path and private key file path.)
 bal run security_jwt_issue_validate.bal

--- a/examples/security-jwt-issue-validate/security_jwt_issue_validate.out
+++ b/examples/security-jwt-issue-validate/security_jwt_issue_validate.out
@@ -1,5 +1,5 @@
-# (You may need to change the certificate file path, trusted certificate file
-# path and private key file path.)
+# You may need to change the certificate file path, private key file path, and
+# trusted certificate file path.
 bal run security_jwt_issue_validate.bal
 Issued JWT: eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkR
             nM01UVTFaR00wTXpFek9ESmhaV0k0TkRObFpEVTFPR0ZrTmpGaU1RIn0.eyJpc3MiOi

--- a/examples/url-encode-decode/url_encode_decode.out
+++ b/examples/url-encode-decode/url_encode_decode.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the `.bal` file,
-# and execute the `bal run` command below.
 bal run url_encode_decode.bal
 URL encoded value: data%3Dvalue
 URL decoded value: data=value


### PR DESCRIPTION
## Purpose
$subject

Removed the instruction:
```
# To start the service, navigate to the directory that contains the
# `.bal` file and use the `bal run` command below.
```
Related to: Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584