### PR TITLE
Update instructions in WebSub BBE

### DIFF
--- a/examples/websub-webhook-sample/websub_webhook_sample.out
+++ b/examples/websub-webhook-sample/websub_webhook_sample.out
@@ -1,5 +1,3 @@
-# To start the service, navigate to the directory that contains the
-# `.bal` file, and execute the `bal run` command below.
 bal run websub_webhook_sample.bal
 time = 2021-03-15 15:43:00,198 level = INFO  module = ballerina/websub message = "HTTPS is recommended but using HTTP" 
 time = 2021-03-15 15:43:01,960 level = INFO  module = ballerina/websub message = "Subscription request considered successful for non 202 status code: 204" 


### PR DESCRIPTION
## Purpose
> $subject

Removed the instruction:

```ballerina
# To start the service, navigate to the directory that contains the
# `.bal` file and use the `bal run` command below.
```