### PR TITLE
Update instructions in HTTP BBEs

### DIFF
--- a/examples/http-100-continue/http_100_continue.server.out
+++ b/examples/http-100-continue/http_100_continue.server.out
@@ -1,5 +1,3 @@
-# To start the service, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_expect_header.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090
 time = 2021-01-21 20:31:28,347 level = INFO  module = "" message = "TEST 100 CONTINUE"

--- a/examples/http-circuit-breaker/http_circuit_breaker.server.out
+++ b/examples/http-circuit-breaker/http_circuit_breaker.server.out
@@ -1,5 +1,3 @@
-# To start the services, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_circuit_breaker.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090
 [ballerina/http] started HTTP/WS listener 0.0.0.0:8080

--- a/examples/http-client-endpoint/http_client_endpoint.out
+++ b/examples/http-client-endpoint/http_client_endpoint.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the
-# `.bal` file, and execute the `bal run` command below.
 bal run http_client_endpoint.bal
 GET request:
 {"args":{"test":"123"}, "headers":{"x-forwarded-proto":"http", "x-forwarded-port":"80", "host":"postman-echo.com", "x-amzn-trace-id":"Root=1-5f6acc0b-5f17f7991ebad5eb7f01c723", "user-agent":"ballerina"}, "url":"http://postman-echo.com/get?test=123"}

--- a/examples/http-compression/http_compression.server.out
+++ b/examples/http-compression/http_compression.server.out
@@ -1,5 +1,3 @@
-# To start the services, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_compression.bal
 # Service deployment
 ballerina: started HTTP/WS listener 0.0.0.0:9092

--- a/examples/http-cookies/cookie_server.out
+++ b/examples/http-cookies/cookie_server.out
@@ -1,4 +1,2 @@
-# To run this sample, navigate to the directory that contains the
-# `.bal` file, and execute the `bal run` command below.
 bal run cookie_server.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9095

--- a/examples/http-cookies/http_client.out
+++ b/examples/http-cookies/http_client.out
@@ -1,4 +1,2 @@
-# To run this sample, navigate to the directory that contains the
-# `.bal` file, and execute the `bal run` command below.
 bal run http_client.bal
 time = 2020-12-15 16:14:08,691 level = INFO  module = "" message = "Welcome back John"

--- a/examples/http-cors/http_cors.server.out
+++ b/examples/http-cors/http_cors.server.out
@@ -1,4 +1,2 @@
-# To start the service, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_cors.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9092

--- a/examples/http-disable-chunking/http_disable_chunking.server.out
+++ b/examples/http-disable-chunking/http_disable_chunking.server.out
@@ -1,5 +1,3 @@
-# To start the services, navigate to the directory that contains the
-# `.bal` file and execute the `bal run` command below.
 bal run http_disable_chunking.bal
 # Service deployment
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090

--- a/examples/http-failover/http_failover.server.out
+++ b/examples/http-failover/http_failover.server.out
@@ -1,5 +1,3 @@
-# To start the services, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_failover.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:8080
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090

--- a/examples/http-load-balancer/http_load_balancer.server.out
+++ b/examples/http-load-balancer/http_load_balancer.server.out
@@ -1,5 +1,3 @@
-# To start the services, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_load_balancer.bal
 # Service deployment
 [ballerina/http] started HTTP/WS listener 0.0.0.0:8080

--- a/examples/http-passthrough/http_passthrough.server.out
+++ b/examples/http-passthrough/http_passthrough.server.out
@@ -1,5 +1,3 @@
-# To start the service, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run passthrough.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9092
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090

--- a/examples/http-query-parameter/http_query_parameter.server.out
+++ b/examples/http-query-parameter/http_query_parameter.server.out
@@ -1,4 +1,2 @@
-# To start the service, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_query_parameter.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090

--- a/examples/http-redirects/http_redirects.out
+++ b/examples/http-redirects/http_redirects.out
@@ -1,5 +1,3 @@
-# To run this sample, navigate to the directory that contains the
-# `.bal` file, and execute the `bal run` command below.
 bal run http_redirects.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9092

--- a/examples/http-request-with-multiparts/http_request_with_multiparts.server.out
+++ b/examples/http-request-with-multiparts/http_request_with_multiparts.server.out
@@ -1,7 +1,5 @@
 # In the directory, which contains the `.bal` file, create a directory named `file`,
 # and add an XML files named `test.xml` in it.
-# To start the service, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run request_with_multiparts.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090
 time = 2021-01-21 22:00:17,167 level = INFO  module = "" message = "{"name":"ballerina"}"

--- a/examples/http-response-with-multiparts/http_response_with_multiparts.server.out
+++ b/examples/http-response-with-multiparts/http_response_with_multiparts.server.out
@@ -1,7 +1,5 @@
 # In the directory, which contains the `.bal` file, create a directory named `files`,
 # and add an XML file named `test.xml` in it.
-# To start the service, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run response_with_multiparts.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9092

--- a/examples/http-retry/http_retry.server.out
+++ b/examples/http-retry/http_retry.server.out
@@ -1,5 +1,3 @@
-# To start the services, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_retry.bal.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090
 [ballerina/http] started HTTP/WS listener 0.0.0.0:8080

--- a/examples/http-streaming/http_streaming.server.out
+++ b/examples/http-streaming/http_streaming.server.out
@@ -1,6 +1,4 @@
 # In the directory, which contains the `.bal` file, create a directory named `files`,
 # and add a PDF file named `BallerinaLang.pdf` in it.
-# To start the service, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_streaming.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090

--- a/examples/http-timeout/http_timeout.server.out
+++ b/examples/http-timeout/http_timeout.server.out
@@ -1,5 +1,3 @@
-# To start the services, navigate to the directory that contains the
-# `.bal` file and use the `bal run` command below.
 bal run http_timeout.bal
 [ballerina/http] started HTTP/WS listener 0.0.0.0:9090
 [ballerina/http] started HTTP/WS listener 0.0.0.0:8080


### PR DESCRIPTION
## Purpose
> $subject

Removed the instruction:
```ballerina
# To start the service, navigate to the directory that contains the
# `.bal` file and use the `bal run` command below.
```