### PR TITLE
Enable Output Verification for GraphQL BBEs

### DIFF
--- a/examples/index.json
+++ b/examples/index.json
@@ -1278,7 +1278,7 @@
                 "name": "Hierarchical Resource Paths",
                 "url": "graphql-hierarchical-resource-paths",
                 "verifyBuild": true,
-                "verifyOutput": false,
+                "verifyOutput": true,
                 "disablePlayground": true,
                 "isLearnByExample": false
             },
@@ -1286,7 +1286,7 @@
                 "name": "Returning Service Objects",
                 "url": "graphql-returning-service-objects",
                 "verifyBuild": true,
-                "verifyOutput": false,
+                "verifyOutput": true,
                 "disablePlayground": true,
                 "isLearnByExample": false
             },


### PR DESCRIPTION
## Purpose
$Subject

The output verification of these BBEs are disabled due to https://github.com/ballerina-platform/ballerina-standard-library/issues/1505.

This should be merged after merging https://github.com/ballerina-platform/module-ballerina-graphql/pull/306