### PR TITLE
Change build.gradle configuration for OpenAPI Tool

### DIFF
--- a/ballerina-test/src/test/java/org/ballerinalang/distribution/test/OpenAPIDistributionArtifactCheck.java
+++ b/ballerina-test/src/test/java/org/ballerinalang/distribution/test/OpenAPIDistributionArtifactCheck.java
@@ -86,11 +86,20 @@ public class OpenAPIDistributionArtifactCheck {
                 .resolve("ballerina")
                 .resolve("openapi");
 
+        Path languageExtension = TEST_DISTRIBUTION_PATH
+                .resolve(DIST_NAME)
+                .resolve("lib")
+                .resolve("tools")
+                .resolve("lang-server")
+                .resolve("lib");
+
         Assert.assertTrue(Files.exists(birPath));
         Assert.assertTrue(Files.exists(balaPath));
         Assert.assertTrue(Files.exists(jarPath.resolve("ballerina-openapi-0.9.0-beta.3.jar")));
         Assert.assertNotNull(TestUtils.findFileOrDirectory(breLibPath, "openapi-cli-"));
         Assert.assertNotNull(TestUtils.findFileOrDirectory(breLibPath, "openapi-validator-"));
+        Assert.assertNotNull(TestUtils.findFileOrDirectory(breLibPath, "openapi-bal-service-"));
+        Assert.assertNotNull(TestUtils.findFileOrDirectory(languageExtension, "openapi-ls-"));
         Assert.assertTrue(Files.exists(docsPath));
     }
 

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -94,6 +94,17 @@ task unpackStdLibs() {
     }
 }
 
+task unpackOpenAPILibs() {
+    doLast {
+        configurations.ballerinaOpenAPILibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            copy {
+                from project.zipTree(artifact.getFile())
+                into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+            }
+        }
+    }
+}
+
 task unpackC2cLibs() {
     doLast {
         configurations.ballerinaC2cLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
@@ -169,6 +180,23 @@ task copyOtherRepos(type: Copy) {
         }
         from("${artifactExtractedPath}/cache") {
             into "repo/cache"
+        }
+    }
+
+    /* OpenAPI Libraries */
+    configurations.ballerinaOpenAPILibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+        from("${artifactExtractedPath}/libs") {
+            into "bre/lib/"
+        }
+        from("${artifactExtractedPath}/bala") {
+            into "repo/bala"
+        }
+        from("${artifactExtractedPath}/cache") {
+            into "repo/cache"
+        }
+        from("${artifactExtractedPath}/lslibs") {
+            into "lib/tools/lang-server/lib/"
         }
     }
 
@@ -1065,7 +1093,8 @@ task testDevToolsIntegration() {
 unpackJballerinaTools.dependsOn unpackBallerinaJre
 unpackDevTools.dependsOn unpackJballerinaTools
 unpackStdLibs.dependsOn unpackDevTools
-unpackC2cLibs.dependsOn unpackStdLibs
+unpackOpenAPILibs.dependsOn unpackStdLibs
+unpackC2cLibs.dependsOn unpackOpenAPILibs
 unpackC2cTooling.dependsOn unpackC2cLibs
 downloadBalCommand.dependsOn unpackC2cTooling
 

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ subprojects {
         ballerinaStdLibs
         ballerinaC2cLibs
         ballerinaC2cTooling
+        ballerinaOpenAPILibs
         exten {
             transitive = false
         }
@@ -178,7 +179,8 @@ subprojects {
         ballerinaStdLibs "io.ballerina.stdlib:xslt-ballerina:${stdlibXsltVersion}"
 
         ballerinaStdLibs "org.ballerinalang:transaction-ballerina:${stdlibTransactionVersion}"
-        ballerinaStdLibs "io.ballerina:module-ballerina-openapi:${openapiVersion}"
+        ballerinaOpenAPILibs "io.ballerina:module-ballerina-openapi:${openapiVersion}"
+
 
         /* Code to cloud extensions */
         ballerinaC2cLibs "io.ballerina:c2c-ballerina:${c2cVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -179,8 +179,9 @@ subprojects {
         ballerinaStdLibs "io.ballerina.stdlib:xslt-ballerina:${stdlibXsltVersion}"
 
         ballerinaStdLibs "org.ballerinalang:transaction-ballerina:${stdlibTransactionVersion}"
-        ballerinaOpenAPILibs "io.ballerina:module-ballerina-openapi:${openapiVersion}"
 
+        /* Ballerina OpenAPI */
+        ballerinaOpenAPILibs "io.ballerina:module-ballerina-openapi:${openapiVersion}"
 
         /* Code to cloud extensions */
         ballerinaC2cLibs "io.ballerina:c2c-ballerina:${c2cVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ devToolsVersion=0.10.6
 ballerinaCommandVersion=1.3.6
 
 # Open API Module
-openapiVersion=0.9.0-beta.3-20210721-135900-824bc33
+openapiVersion=0.9.0-beta.3-20210803-164600-684e13b
 
 # Ballerinax extensions
 dockerVersion=2.0.0-beta.3-20210721-122500-77ce0d8


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-platform/ballerina-openapi/issues/469

## Goals
> Introduce the new  `ballerinaOpenAPILibs` gradle configuration for packing the openAPI jars to the final distribution.