### PR TITLE
Add JWT bearer grant type BBEs for HTTP, WebSocket and gRPC

### DIFF
--- a/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client.out
+++ b/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client.out
@@ -1,0 +1,7 @@
+# Create a new Protocol Buffers definition file named `grpc_client.proto` and add the service definition to it.
+# Run the command below in the Ballerina tools distribution for stub generation.
+bal grpc --input grpc_client.proto --output stubs
+
+# Once you run the command, `grpc_client_pb.bal` file is generated inside stubs directory.
+
+# For more information on how to use the Ballerina Protocol Buffers tool, see the [Proto To Ballerina](https://ballerina.io/learn/by-example/proto-to-ballerina.html) example.

--- a/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client.proto
+++ b/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client.proto
@@ -1,0 +1,8 @@
+// This is the service definition for the scenario.
+syntax = "proto3";
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
+
+service HelloWorld {
+	rpc hello(google.protobuf.Empty) returns (google.protobuf.StringValue);
+}

--- a/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.bal
+++ b/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.bal
@@ -2,7 +2,7 @@ import ballerina/io;
 
 // Defines the gRPC client to call the OAuth2 secured APIs.
 // The client metadata is enriched with the `Authorization: Bearer <token>`
-// header by passing the [`http:OAuth2JwtBearerGrantConfig`](https://docs.central.ballerina.io/ballerina/grpc/latest/records/OAuth2JwtBearerGrantConfig) for the `auth`
+// header by passing the [`grpc:OAuth2JwtBearerGrantConfig`](https://docs.central.ballerina.io/ballerina/grpc/latest/records/OAuth2JwtBearerGrantConfig) for the `auth`
 // configuration of the client.
 HelloWorldClient securedEP = check new("https://localhost:9090",
     auth = {

--- a/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.bal
+++ b/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.bal
@@ -1,0 +1,28 @@
+import ballerina/io;
+
+// Defines the gRPC client to call the OAuth2 secured APIs.
+// The client metadata is enriched with the `Authorization: Bearer <token>`
+// header by passing the [`http:OAuth2JwtBearerGrantConfig`](https://docs.central.ballerina.io/ballerina/grpc/latest/records/OAuth2JwtBearerGrantConfig) for the `auth`
+// configuration of the client.
+HelloWorldClient securedEP = check new("https://localhost:9090",
+    auth = {
+        tokenUrl: "https://localhost:9445/oauth2/token",
+        assertion: "eyJhbGciOiJFUzI1NiIsImtpZCI6Ij[...omitted for brevity...]",
+        clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+        clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+        scopes: ["admin"],
+        clientConfig: {
+            secureSocket: {
+                cert: "../resource/path/to/public.crt"
+            }
+        }
+    },
+    secureSocket = {
+        cert: "../resource/path/to/public.crt"
+    }
+);
+
+public function main() returns error? {
+    string result = check securedEP->hello();
+    io:println(result);
+}

--- a/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.description
+++ b/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.description
@@ -1,0 +1,7 @@
+// A client, which is secured with an OAuth2 JWT bearer grant type can be
+// used to connect to a secured service.<br/>
+// The client metadata is enriched with the `Authorization: Bearer <token>`
+// header by passing the `grpc:OAuth2JwtBearerGrantConfig` to the `auth`
+// configuration of the client.<br/><br/>
+// For more information on the underlying module,
+// see the [OAuth2 module](https://docs.central.ballerina.io/ballerina/oauth2/latest/).

--- a/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.metatags
+++ b/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.metatags
@@ -1,0 +1,2 @@
+description: BBE on how to secure gRPC client with OAuth2 JWT bearer grant type in Ballerina.
+keywords: ballerina, ballerina by example, bbe, grpc, auth, oauth2, jwt bearer grant type

--- a/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.out
+++ b/examples/grpc-client-oauth2-jwt-bearer-grant-type/grpc_client_oauth2_jwt_bearer_grant_type.out
@@ -1,0 +1,14 @@
+# Create a Ballerina package.
+# Copy the generated `grpc_secured_pb.bal` stub file to the package.
+# For example, if you create a package named `client`, copy the stub file to the `client` package.
+
+# Create a new `grpc_client_oauth2_jwt_bearer_grant_type.bal` Ballerina file inside the `client` package and add the client implementation.
+
+# Execute the command below to build the 'client' package.
+# You may need to change the trusted certificate file path.
+`bal build client`
+
+# Run the client using the command below.
+# As a prerequisite, start a sample service secured with OAuth2.
+bal run client/target/bin/client.jar
+Hello, World!

--- a/examples/grpc-client-oauth2-refresh-token-grant-type/grpc_client_oauth2_refresh_token_grant_type.bal
+++ b/examples/grpc-client-oauth2-refresh-token-grant-type/grpc_client_oauth2_refresh_token_grant_type.bal
@@ -2,7 +2,7 @@ import ballerina/io;
 
 // Defines the gRPC client to call the OAuth2 secured APIs.
 // The client metadata is enriched with the `Authorization: Bearer <token>`
-// header by passing the [`http:OAuth2RefreshTokenGrantConfig`](https://docs.central.ballerina.io/ballerina/grpc/latest/records/OAuth2RefreshTokenGrantConfig) for the `auth`
+// header by passing the [`grpc:OAuth2RefreshTokenGrantConfig`](https://docs.central.ballerina.io/ballerina/grpc/latest/records/OAuth2RefreshTokenGrantConfig) for the `auth`
 // configuration of the client.
 HelloWorldClient securedEP = check new("https://localhost:9090",
     auth = {

--- a/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.bal
+++ b/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.bal
@@ -1,0 +1,29 @@
+import ballerina/http;
+import ballerina/io;
+
+// Defines the HTTP client to call the OAuth2 secured APIs.
+// The client is enriched with the `Authorization: Bearer <token>` header by
+// passing the [`http:OAuth2JwtBearerGrantConfig`](https://docs.central.ballerina.io/ballerina/http/latest/records/OAuth2JwtBearerGrantConfig) for the `auth` configuration of the
+// client.
+http:Client securedEP = check new("https://localhost:9090",
+    auth = {
+        tokenUrl: "https://localhost:9445/oauth2/token",
+        assertion: "eyJhbGciOiJFUzI1NiIsImtpZCI6Ij[...omitted for brevity...]",
+        clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+        clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+        scopes: ["admin"],
+        clientConfig: {
+            secureSocket: {
+                cert: "../resource/path/to/public.crt"
+            }
+        }
+    },
+    secureSocket = {
+        cert: "../resource/path/to/public.crt"
+    }
+);
+
+public function main() returns error? {
+    string response = check securedEP->get("/foo/bar");
+    io:println(response);
+}

--- a/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.description
+++ b/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.description
@@ -1,0 +1,7 @@
+// A client, which is secured with an OAuth2 JWT bearer grant type can be
+// used to connect to a secured service.<br/>
+// The client is enriched with the `Authorization: Bearer <token>` header by
+// passing the `http:OAuth2JwtBearerGrantConfig` to the `auth`
+// configuration of the client.<br/><br/>
+// For more information on the underlying module,
+// see the [OAuth2 module](https://docs.central.ballerina.io/ballerina/oauth2/latest/).

--- a/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.metatags
+++ b/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.metatags
@@ -1,0 +1,2 @@
+description: BBE on how to secure HTTP client with OAuth2 JWT bearer grant type in Ballerina.
+keywords: ballerina, ballerina by example, bbe, http, auth, oauth2, jwt bearer grant type

--- a/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.out
+++ b/examples/http-client-oauth2-jwt-bearer-grant-type/http_client_oauth2_jwt_bearer_grant_type.out
@@ -1,0 +1,4 @@
+# As a prerequisite, start a sample service secured with OAuth2.
+# You may need to change the trusted certificate file path.
+bal run http_client_oauth2_jwt_bearer_grant_type.bal
+Hello, World!

--- a/examples/index.json
+++ b/examples/index.json
@@ -1163,6 +1163,14 @@
                 "verifyOutput": false,
                 "disablePlayground": true,
                 "isLearnByExample": false
+            },
+            {
+                "name": "Client - OAuth2 JWT Bearer Grant Type",
+                "url": "http-client-oauth2-jwt-bearer-grant-type",
+                "verifyBuild": true,
+                "verifyOutput": false,
+                "disablePlayground": true,
+                "isLearnByExample": false
             }
         ]
     },
@@ -1532,6 +1540,14 @@
                 "verifyOutput": false,
                 "disablePlayground": true,
                 "isLearnByExample": false
+            },
+            {
+                "name": "Client - OAuth2 JWT Bearer Grant Type",
+                "url": "websocket-client-oauth2-jwt-bearer-grant-type",
+                "verifyBuild": true,
+                "verifyOutput": false,
+                "disablePlayground": true,
+                "isLearnByExample": false
             }
         ]
     },
@@ -1785,6 +1801,14 @@
             {
                 "name": "Client - OAuth2 Refresh Token Grant Type",
                 "url": "grpc-client-oauth2-refresh-token-grant-type",
+                "verifyBuild": true,
+                "verifyOutput": false,
+                "disablePlayground": true,
+                "isLearnByExample": false
+            },
+            {
+                "name": "Client - OAuth2 JWT Bearer Grant Type",
+                "url": "grpc-client-oauth2-jwt-bearer-grant-type",
                 "verifyBuild": true,
                 "verifyOutput": false,
                 "disablePlayground": true,

--- a/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.bal
+++ b/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.bal
@@ -1,0 +1,30 @@
+import ballerina/io;
+import ballerina/websocket;
+
+// Defines the WebSocket client to call the OAuth2 secured APIs.
+// The client is enriched with the `Authorization: Bearer <token>` header by
+// passing the [`websocket:OAuth2JwtBearerGrantConfig`](https://docs.central.ballerina.io/ballerina/websocket/latest/records/OAuth2JwtBearerGrantConfig) for the `auth` configuration of the
+// client.
+websocket:Client securedEP = check new("wss://localhost:9090/foo/bar",
+    auth = {
+        tokenUrl: "https://localhost:9445/oauth2/token",
+        assertion: "eyJhbGciOiJFUzI1NiIsImtpZCI6Ij[...omitted for brevity...]",
+        clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+        clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+        scopes: ["admin"],
+        clientConfig: {
+            secureSocket: {
+                cert: "../resource/path/to/public.crt"
+            }
+        }
+    },
+    secureSocket = {
+        cert: "../resource/path/to/public.crt"
+    }
+);
+
+public function main() returns error? {
+    check securedEP->writeTextMessage("Hello, World!");
+    string textMessage = check securedEP->readTextMessage();
+    io:println(textMessage);
+}

--- a/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.description
+++ b/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.description
@@ -1,0 +1,7 @@
+// A client, which is secured with an OAuth2 JWT bearer grant type can be
+// used to connect to a secured service.<br/>
+// The client is enriched with the `Authorization: Bearer <token>` header by
+// passing the `websocket:OAuth2JwtBearerGrantConfig` to the `auth`
+// configuration of the client.<br/><br/>
+// For more information on the underlying module,
+// see the [OAuth2 module](https://docs.central.ballerina.io/ballerina/oauth2/latest/).

--- a/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.metatags
+++ b/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.metatags
@@ -1,0 +1,2 @@
+description: BBE on how to secure WebSocket client with OAuth2 JWT bearer grant type in Ballerina.
+keywords: ballerina, ballerina by example, bbe, websocket, auth, oauth2, jwt bearer grant type

--- a/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.out
+++ b/examples/websocket-client-oauth2-jwt-bearer-grant-type/websocket_client_oauth2_jwt_bearer_grant_type.out
@@ -1,0 +1,4 @@
+# As a prerequisite, start a sample service secured with OAuth2.
+# You may need to change the trusted certificate file path.
+bal run websocket_client_oauth2_jwt_bearer_grant_type.bal
+Hello, World!

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,16 +36,16 @@ stdlibUuidVersion=1.0.0-20210816-151300-92124cc
 stdlibAuthVersion=2.0.0-20210816-152100-c3cf8c7
 stdlibEmailVersion=2.0.0-20210816-152300-7e3f194
 stdlibJwtVersion=2.0.0-20210816-152100-2d287f8
-stdlibOAuth2Version=2.0.0-20210816-152400-9bb2bdb
+stdlibOAuth2Version=2.0.0-20210817-153400-d6dec5e
 
 # Stdlib Level 05
-stdlibHttpVersion=2.0.0-20210816-155900-35a4360
+stdlibHttpVersion=2.0.0-20210817-162200-389a5b8
 
 # Stdlib Level 06
 stdlibGraphqlVersion=1.0.0-20210816-163300-d8444ad
-stdlibGrpcVersion=1.0.0-20210816-163500-d3c5540
+stdlibGrpcVersion=1.0.0-20210817-163100-752ab95
 stdlibTransactionVersion=1.0.15-20210816-163300-3d9788e
-stdlibWebsocketVersion=2.0.0-20210816-163800-6abfb83
+stdlibWebsocketVersion=2.0.0-20210817-161000-f1a8667
 stdlibWebsubVersion=2.0.0-20210816-163400-4f3e76a
 stdlibWebsubhubVersion=1.0.0-20210816-163400-6f30ce6
 


### PR DESCRIPTION
## Purpose
This PR adds JWT bearer grant type BBEs for HTTP, WebSocket and gRPC.

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/1788