### PR TITLE
Add debugger integration test for service variables

### DIFF
--- a/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
+++ b/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
@@ -55,12 +55,18 @@ public class ServiceDebugTest extends BaseTestCase {
         int port = findFreePort();
 
         debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath, port);
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 22));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 20));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 24));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.BUILD, port);
 
-        // Test for service debug where service is in the default module
+        // test for debug hits in service level variables
         Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
         Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
+
+        // test for debug instructions within service
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(1));
     }
 
     @Test(description = "Test for service call stack representation")

--- a/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
+++ b/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
@@ -16,8 +16,10 @@
 
 import ballerina/http;
 
-service on new http:Listener(9191) {
-    resource function get sayHello(http:Caller caller, http:Request req) returns error? {
-            check caller->respond("Hello, World!");
+service / on new http:Listener(9090) {
+    final int x = 5;
+
+    resource function get greeting() returns string {
+        return "Hello, World!";
     }
 }

--- a/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
+++ b/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
@@ -16,10 +16,10 @@
 
 import ballerina/http;
 
-service / on new http:Listener(9090) {
+service / on new http:Listener(9191) {
     final int x = 5;
 
-    resource function get greeting() returns string {
+    resource function get sayHello() returns string {
         return "Hello, World!";
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds debugger integration test to verify debug instructions handling for service level variables.

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/32732

## Remarks
Should be merged after https://github.com/ballerina-platform/ballerina-lang/pull/32732