### PR TITLE
Fix downloading ballerina-windows zip file in release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -218,6 +218,8 @@ jobs:
           dotnet-version: '2.1.x'
       - name: Install GUID Generator
         run: dotnet tool install -g dotnet-guid
+      - name: Install Wget
+        run: choco install wget --no-progress
       - name: Download Windows Intaller Zip
         run: |
           wget https://github.com/ballerina-platform/ballerina-distribution/releases/download/v${{ needs.publish-release.outputs.release-version }}/ballerina-windows-${{ needs.publish-release.outputs.project-version }}.zip


### PR DESCRIPTION
## Purpose
Fix downloading ballerina-windows zip file to generate windows msi installer in release.

## Approach
Add step to download wget in windows runner