### PR TITLE
Add debugger integration test for service variables

### DIFF
--- a/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
+++ b/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
@@ -64,10 +64,16 @@ public class ServiceDebugTest extends BaseTestCase {
         Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
         Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
 
-        // test for debug instructions within service
+        // Timeout Exception is expected, since the service get started once the VM is resumed and resource
+        // function cannot have any debug hits until an HTTP request is received.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
-        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
-        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(1));
+        try {
+            debugTestRunner.waitForDebugHit(10000);
+        } catch (BallerinaTestException e) {
+            if (!e.getMessage().equals("Timeout expired waiting for the debug hit")) {
+                throw e;
+            }
+        }
     }
 
     @Test(description = "Test for service call stack representation")
@@ -77,13 +83,13 @@ public class ServiceDebugTest extends BaseTestCase {
         int port = findFreePort();
 
         debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath.toString(), port);
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 21));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 20));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.BUILD, port);
 
         // Test for service call stack representation
         Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
         StackFrame[] frames = debugTestRunner.fetchStackFrames(debugHitInfo.getRight());
-        debugTestRunner.assertCallStack(frames[0], "sayHello", 21, "hello_service.bal");
+        debugTestRunner.assertCallStack(frames[0], "service", 20, "hello_service.bal");
     }
 
     @Test(description = "Test for single bal file debug engage")

--- a/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
+++ b/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.ballerinalang.debugger.test.utils.DebugUtils.findFreePort;
@@ -51,7 +52,7 @@ public class ServiceDebugTest extends BaseTestCase {
     @Test(description = "Test for service module debug engage")
     public void testModuleServiceDebugScenarios() throws BallerinaTestException {
         String fileName = "hello_service.bal";
-        String filePath = Paths.get(debugTestRunner.testProjectPath, fileName).toString();
+        Path filePath = Paths.get(debugTestRunner.testProjectPath, fileName);
         int port = findFreePort();
 
         debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath, port);
@@ -72,7 +73,7 @@ public class ServiceDebugTest extends BaseTestCase {
     @Test(description = "Test for service call stack representation")
     public void serviceCallStackDebugTest() throws BallerinaTestException {
         String fileName = "hello_service.bal";
-        String filePath = Paths.get(debugTestRunner.testProjectPath, fileName).toString();
+        Path filePath = Paths.get(debugTestRunner.testProjectPath, fileName);
         int port = findFreePort();
 
         debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath, port);

--- a/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
+++ b/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
@@ -55,12 +55,18 @@ public class ServiceDebugTest extends BaseTestCase {
         int port = findFreePort();
 
         debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath, port);
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 22));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 20));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 24));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.BUILD, port);
 
-        // Test for service debug where service is in the default module
+        // test for debug hits in service level variables
         Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
         Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
+
+        // test for debug instructions within service
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(1));
     }
 
     @Test(description = "Test for service call stack representation")

--- a/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
+++ b/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
@@ -16,8 +16,10 @@
 
 import ballerina/http;
 
-service on new http:Listener(9191) {
-    resource function get sayHello(http:Caller caller, http:Request req) returns error? {
-            check caller->respond("Hello, World!");
+service / on new http:Listener(9090) {
+    final int x = 5;
+
+    resource function get greeting() returns string {
+        return "Hello, World!";
     }
 }

--- a/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
+++ b/devtools-integration-tests/src/test/resources/debug/project-based-tests/service-tests/hello_service.bal
@@ -16,10 +16,10 @@
 
 import ballerina/http;
 
-service / on new http:Listener(9090) {
+service / on new http:Listener(9191) {
     final int x = 5;
 
-    resource function get greeting() returns string {
+    resource function get sayHello() returns string {
         return "Hello, World!";
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds debugger integration test to verify debug instructions handling for service level variables.

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/32732

## Remarks
Should be merged after https://github.com/ballerina-platform/ballerina-lang/pull/32732