### PR TITLE
Add BBEs for installer tests as project tests

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -94,7 +94,7 @@ jobs:
         run: sudo dpkg -i installers/linux-deb/target/ballerina-linux-installer-x64-*.deb
       - name: Run Installer Tests
         working-directory: ./ballerina-test-automation/installer-test
-        run: .././gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true
+        run: ./../gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true
       - name: Notify failure
         if: ${{ failure() }}
         run: |
@@ -208,7 +208,7 @@ jobs:
         working-directory: ./ballerina-test-automation/installer-test
         run: |
           bal -v
-          .././gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true
+          ./../gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true
 
   macos-installer-build:
 
@@ -245,7 +245,7 @@ jobs:
         run: sudo installer -pkg installers/mac/target/pkg/ballerina-macos-installer-x64-*.pkg -target /
       - name: Run Installer Tests
         working-directory: ./ballerina-test-automation/installer-test
-        run: .././gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true
+        run: ./../gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true
 
   windows-installer-build:
 

--- a/ballerina-test-automation/installer-test/build.gradle
+++ b/ballerina-test-automation/installer-test/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':test-automation')
     implementation 'org.testng:testng:6.14.3'
     testCompile 'org.testng:testng'
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 }
 
 repositories {

--- a/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/ProjectTest.java
+++ b/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/ProjectTest.java
@@ -49,4 +49,19 @@ public class ProjectTest {
             executor.cleanArtifacts();
         }
     }
+
+    @Test(dataProvider = "getExecutors")
+    public void testBBEs(Executor executor) throws InterruptedException {
+        if (!System.getProperty("BALLERINA_INSTALLED").equals("true")) {
+            executor.transferArtifacts();
+            executor.install();
+        }
+
+        TestUtils.testBBEs(executor, version, specVersion, toolVersion);
+
+        if (!System.getProperty("BALLERINA_INSTALLED").equals("true")) {
+            executor.uninstall();
+            executor.cleanArtifacts();
+        }
+    }
 }


### PR DESCRIPTION
## Purpose
Build BBEs against installers to check the installers.

## Goals
To run more tests on installers.

## Approach
Added a new test 'testBBEs' to project tests. In the gradle build, the test will run and build BBEs.
running command - `bal init && bal build`

## Fixes https://github.com/ballerina-platform/ballerina-distribution/issues/2379

