### PR TITLE
Create a workflow to test signed pkg installer

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -1,0 +1,39 @@
+name: Test Installers
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Version of the release. e.g., swan-lake-beta1'
+        required: true
+      preReleaseSuffix:
+        description: 'The text that will be suffixed to the Git tag. e.g., rc1'
+        required: false
+        default: ''
+
+jobs:
+  macos-installer-test:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set Version
+        id: set-version
+        run: |
+          RELEASE_VERSION=${{ github.event.inputs.releaseVersion }}
+          TAGGED_VERSION=$RELEASE_VERSION
+          if [ -n "${{ github.event.inputs.preReleaseSuffix }}" ]; then
+            TAGGED_VERSION=$RELEASE_VERSION-${{ github.event.inputs.preReleaseSuffix }}
+          fi
+          echo VERSION=$RELEASE_VERSION >> $GITHUB_ENV
+          echo GIT_TAG=$TAGGED_VERSION >> $GITHUB_ENV
+          echo "::set-output name=version::$RELEASE_VERSION"
+          echo "::set-output name=taggedVersion::$TAGGED_VERSION"
+      - name: Download Ballerina pkg Installer
+        run: wget https://github.com/ballerina-platform/ballerina-distribution/releases/download/v${{ steps.set-version.outputs.taggedVersion }}/ballerina-macos-installer-x64-${{ steps.set-version.outputs.version }}.pkg
+      - name: Install Ballerina pkg
+        run: sudo installer -pkg ballerina-macos-installer-x64-${{ steps.set-version.outputs.version }}.pkg -target /
+      - name: Run Installer Tests
+        working-directory: ./ballerina-test-automation/installer-test
+        run: ./../gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true


### PR DESCRIPTION
## Purpose
Test signed pkg installer by running installer tests

## Goals
Test release artifacts after the signing process

## Fixes
https://github.com/ballerina-platform/ballerina-distribution/issues/2424