### PR TITLE
Run installer tests for windows msi installer

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -298,6 +298,14 @@ jobs:
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-windows-installer-x64-*.msi
+      - name: Install Ballerina msi
+        run: msiexec /i w\target\msi\ballerina-windows-installer-x64-${{ needs.ubuntu-build.outputs.project-version }}.msi /quiet /qr
+        shell: cmd
+      - name: Run Installer Tests
+        working-directory: .\ballerina-test-automation\installer-test
+        run: |
+          $env:Path += ";C:\Program Files\Ballerina\bin"
+          .\..\gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true
 
   trigger-notifications:
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -308,3 +308,11 @@ jobs:
           asset_name: ballerina-windows-installer-x64-${{ needs.publish-release.outputs.project-version }}.msi
           asset_path: w\target\msi\ballerina-windows-installer-x64-${{ needs.publish-release.outputs.project-version }}.msi
           asset_content_type: application/octet-stream
+      - name: Install Ballerina msi
+        run: msiexec /i w\target\msi\ballerina-windows-installer-x64-${{ needs.publish-release.outputs.project-version }}.msi /quiet /qr
+        shell: cmd
+      - name: Run Installer Tests
+        working-directory: .\ballerina-test-automation\installer-test
+        run: |
+          $env:Path += ";C:\Program Files\Ballerina\bin"
+          .\..\gradlew build --stacktrace -scan --console=plain --no-daemon -DballerinaInstalled=true

--- a/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/TestUtils.java
+++ b/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/TestUtils.java
@@ -55,8 +55,8 @@ public class TestUtils {
                                           String versionDisplayText) {
         String toolText = TestUtils.isOldToolVersion(toolVersion) ? "Ballerina tool" : "Update Tool";
         if (jBallerinaVersion.contains(TestUtils.SWAN_LAKE_KEYWORD)) {
-            return "Ballerina Swan Lake " + versionDisplayText + System.lineSeparator() + "Language specification "
-                    + specVersion + System.lineSeparator() + toolText + " " + toolVersion + System.lineSeparator();
+            return "Ballerina Swan Lake " + versionDisplayText + "\nLanguage specification "
+                    + specVersion + "\n" + toolText + " " + toolVersion + "\n";
         }
 
         String ballerinaReference = isSupportedRelease(jBallerinaVersion) ? "jBallerina" : "Ballerina";


### PR DESCRIPTION
## Purpose
Run installer tests for windows msi installer in daily build and release workflows.

## Goals
Increase the tests for release artifacts.

## Fixes
https://github.com/ballerina-platform/ballerina-distribution/issues/2427