### PR TITLE
Automate UUID generation during release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,6 +47,14 @@ jobs:
           git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
           git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
           git checkout -b release-${GIT_TAG}
+      - name: Generate UUID
+        run: |
+          UUID=$(uuidgen)
+          perl -pi -e "s/^\s*installerVersion=.*/installerVersion=$UUID/" gradle.properties
+          git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add gradle.properties
+          git commit -m "Update UUID for installer"
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Publish artifact


### PR DESCRIPTION
## Purpose
Automate UUID generation during release workflow

## Goals
Automate the release workflow

## Fixes
https://github.com/ballerina-platform/ballerina-distribution/issues/2431 