### PR TITLE
Run tests on BBEs

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -721,12 +721,14 @@ task testExamples() {
                 ignoreExitValue true
                 workingDir "${distPath}/${bbe.url}"
                 commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'build', '--experimental', "${additionalBuildParams}"
+                commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'test'
             }
         } else {
             exitVal = exec {
                 ignoreExitValue true
                 workingDir "${distPath}/${bbe.url}"
                 commandLine 'sh', '-c', "${distPath}/bin/bal build --experimental ${additionalBuildParams}"
+                commandLine 'sh', '-c', "${distPath}/bin/bal test"
             }
         }
         if (exitVal.getExitValue() == 1) {

--- a/examples/http-trace-logs/http_trace_logs.bal
+++ b/examples/http-trace-logs/http_trace_logs.bal
@@ -3,7 +3,7 @@ import ballerina/http;
 service /hello on new http:Listener(9090) {
 
     resource function get .(http:Request req) returns http:Response|error {
-        http:Client clientEP = check new ("http://httpstat.us");
+        http:Client clientEP = check new ("https://httpstat.us");
         http:Response resp = check clientEP->forward("/200", req);
         return resp;
     }


### PR DESCRIPTION
## Purpose
Run tests on BBEs to reduce failures.

## Goals
Currently BBEs are only built using `bal build` command. This will run `bal test` command on BBEs

## Fixes
https://github.com/ballerina-platform/ballerina-distribution/issues/2430
https://github.com/ballerina-platform/ballerina-standard-library/issues/2554