### PR TITLE
Add test to check directory path with spaces

### DIFF
--- a/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/ProjectTest.java
+++ b/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/ProjectTest.java
@@ -64,4 +64,19 @@ public class ProjectTest {
             executor.cleanArtifacts();
         }
     }
+
+    @Test(dataProvider = "getExecutors")
+    public void testDirectoryPath(Executor executor) throws InterruptedException {
+        if (!System.getProperty("BALLERINA_INSTALLED").equals("true")) {
+            executor.transferArtifacts();
+            executor.install();
+        }
+
+        TestUtils.testDirectoryPath(executor, toolVersion);
+
+        if (!System.getProperty("BALLERINA_INSTALLED").equals("true")) {
+            executor.uninstall();
+            executor.cleanArtifacts();
+        }
+    }
 }

--- a/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/TestUtils.java
+++ b/ballerina-test-automation/installer-test/src/test/java/io/ballerina/installer/test/TestUtils.java
@@ -328,4 +328,38 @@ public class TestUtils {
         }
         return version;
     }
+
+    public static void testDirectoryPath(Executor executor, String toolVersion) throws InterruptedException {
+
+        String cmdName = Utils.getCommandName(toolVersion);
+
+        executor.executeCommand("version && mkdir 'test space1' && cd 'test space1' && " + cmdName +
+                "new sampleProject1 && cd sampleProject1 && " + cmdName + "add module1 && " +
+                cmdName + "build", false, toolVersion);
+
+        Path userDir = Paths.get(System.getProperty("user.dir"));
+        Path projectPath1 = userDir.resolve("test space1").resolve("sampleProject1");
+        Assert.assertTrue(Files.exists(projectPath1));
+        Assert.assertTrue(Files.isDirectory(projectPath1.resolve("modules").resolve("module1")));
+        Assert.assertTrue(Files.exists(projectPath1.resolve("target/bin/sampleProject1.jar")));
+
+        executor.executeCommand("version && mkdir 'test space2' && cd 'test space2' && " + cmdName +
+                "new sampleProject2 && cd sampleProject2 && " + cmdName + "add module1", false, toolVersion);
+        executor.executeCommand("version && " + cmdName + "build 'test space2/sampleProject2'", false, toolVersion);
+
+        Path projectPath2 = userDir.resolve("test space2").resolve("sampleProject2");
+        Assert.assertTrue(Files.exists(projectPath2));
+        Assert.assertTrue(Files.isDirectory(projectPath2.resolve("modules").resolve("module1")));
+        Assert.assertTrue(Files.exists(projectPath2.resolve("target/bin/sampleProject2.jar")));
+
+        executor.executeCommand("version && mkdir 'test space3' && cd 'test space3' && " + cmdName +
+                "new 'sample project3' && cd 'sample project3' && " + cmdName + "add module1", false, toolVersion);
+        executor.executeCommand("version && cd 'test space3' && " + cmdName + "build 'sample project3'",
+                false, toolVersion);
+
+        Path projectPath2 = userDir.resolve("test space2").resolve("sampleProject2");
+        Assert.assertTrue(Files.exists(projectPath2));
+        Assert.assertTrue(Files.isDirectory(projectPath2.resolve("modules").resolve("module1")));
+        Assert.assertTrue(Files.exists(projectPath2.resolve("target/bin/sampleProject2.jar")));
+    }
 }


### PR DESCRIPTION
## Purpose
Currently there are some issues regarding the directory paths with spaces where the `bal` command is not working properly. This test will the `bal` command in directories with spaces in different operating systems.

## Goals
Increase the tests to reduce failures in installers

## Approach
Added a new project test called `testDirectoryPath` in installer tests checking three different scenarios.

## Fixes
https://github.com/ballerina-platform/ballerina-distribution/issues/2504
