### PR TITLE
Disable playground for WebSocket Client BBEs

### DIFF
--- a/examples/index.json
+++ b/examples/index.json
@@ -1610,6 +1610,7 @@
                 "url": "websocket-text-client",
                 "verifyBuild": true,
                 "verifyOutput": false,
+                "disablePlayground": true,
                 "isLearnByExample": false
             },
             {
@@ -1617,6 +1618,7 @@
                 "url": "websocket-binary-client",
                 "verifyBuild": true,
                 "verifyOutput": false,
+                "disablePlayground": true,
                 "isLearnByExample": false
             },
             {


### PR DESCRIPTION
## Purpose
We were using `ws://echo.websocket.org` for this example and now they have shut down that echo server. 