### PR TITLE
Fix comment on automatic version bumping

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-# During the release workflow, 'version' will automatically get bumped to the stable version
+# During the release workflow, the following will get bumped automatically
 version=2201.0.0-SNAPSHOT
 codeName=swan-lake
 ballerinaLangVersion=2201.0.0


### PR DESCRIPTION
$subject because the term `version` within the comment breaks the release build scripts