### PR TITLE
Remove redundant `example` usage in kafka BBEs 

### DIFF
--- a/examples/ftp-listener/ftp_listener.bal
+++ b/examples/ftp-listener/ftp_listener.bal
@@ -26,7 +26,7 @@ service on remoteServer {
 
     // When a file event is successfully received, the `onFileChange` method is
     // called.
-    remote function onFileChange(ftp:WatchEvent event) {
+    remote function onFileChange(ftp:WatchEvent & readonly event) {
 
         // `addedFiles` contains the paths of the newly-added files/directories
         // after the last polling was called.

--- a/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
+++ b/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
@@ -3,4 +3,4 @@
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>
 // For more information on the underlying module,
-// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).
+// see the [`kafka` module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
+++ b/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
@@ -3,4 +3,4 @@
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>
 // For more information on the underlying module,
-// see the [Kafka module](https://docs.central.ballerina.io/ballerinax/kafka/latest).
+// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
+++ b/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
@@ -1,4 +1,4 @@
-// This shows how the SASL/PLAIN authentication is done in `kafka:Consumer`.
+// This shows how the SASL/PLAIN authentication is done in the `kafka:Consumer`.
 // For this to work properly, an active Kafka server must be present
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>

--- a/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
+++ b/examples/kafka-authentication-sasl-plain-consumer/kafka_authentication_sasl_plain_consumer.description
@@ -1,5 +1,5 @@
-// This is an example of a Kafka consumer using the SASL/PLAIN authentication.
-// For this example to work properly, an active Kafka server must be present
+// This shows how the SASL/PLAIN authentication is done in `kafka:Consumer`.
+// For this to work properly, an active Kafka server must be present
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>
 // For more information on the underlying module,

--- a/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
+++ b/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
@@ -3,4 +3,4 @@
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>
 // For more information on the underlying module,
-// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).
+// see the [`kafka` module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
+++ b/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
@@ -3,4 +3,4 @@
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>
 // For more information on the underlying module,
-// see the [Kafka module](https://docs.central.ballerina.io/ballerinax/kafka/latest).
+// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
+++ b/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
@@ -1,4 +1,4 @@
-// This shows how the SASL/PLAIN authentication is done in `kafka:Producer`.
+// This shows how the SASL/PLAIN authentication is done in the `kafka:Producer`.
 // For this to work properly, an active Kafka server must be present
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>

--- a/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
+++ b/examples/kafka-authentication-sasl-plain-producer/kafka_authentication_sasl_plain_producer.description
@@ -1,5 +1,5 @@
-// This is an example of a Kafka producer using the SASL/PLAIN authentication.
-// For this example to work properly, an active Kafka server must be present
+// This shows how the SASL/PLAIN authentication is done in `kafka:Producer`.
+// For this to work properly, an active Kafka server must be present
 // and it should be configured to use the SASL/PLAIN authentication mechanism.
 // <br/><br/>
 // For more information on the underlying module,

--- a/examples/kafka-consumer-client/kafka_consumer_client.description
+++ b/examples/kafka-consumer-client/kafka_consumer_client.description
@@ -6,4 +6,4 @@
 // this to work properly, an active Kafka broker should be present.
 // <br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).
+// see the [`kafka` module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-client/kafka_consumer_client.description
+++ b/examples/kafka-consumer-client/kafka_consumer_client.description
@@ -6,4 +6,4 @@
 // this example to work properly, an active Kafka broker should be present.
 // <br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://docs.central.ballerina.io/ballerinax/kafka/latest).
+// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-client/kafka_consumer_client.description
+++ b/examples/kafka-consumer-client/kafka_consumer_client.description
@@ -1,9 +1,9 @@
-// This is an example on how to use a `kafka:Consumer` as a simple record
+// This shows how to use a `kafka:Consumer` as a simple record
 // consumer. The records from a subscribed topic can be retrieved using the
 // `poll()` function.
 // This consumer uses the builtin byte array deserializer for both the key and
 // the value, which is the default deserializer in the `kafka:Consumer`. For
-// this example to work properly, an active Kafka broker should be present.
+// this to work properly, an active Kafka broker should be present.
 // <br/><br/>
 // For more information on the underlying module, 
 // see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-group-service/kafka_consumer_group_service.description
+++ b/examples/kafka-consumer-group-service/kafka_consumer_group_service.description
@@ -4,4 +4,4 @@
 // values. For this example to work properly, an active Kafka broker should be
 // present.<br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://docs.central.ballerina.io/ballerinax/kafka/latest).
+// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-group-service/kafka_consumer_group_service.description
+++ b/examples/kafka-consumer-group-service/kafka_consumer_group_service.description
@@ -1,7 +1,6 @@
-// This is an example of a Kafka consumer used as a listener to listen to a
-// given topic/topics. The listener uses a group of concurrent consumers within
-// the service. This consumer uses the builtin `string` deserializer for the
-// values. For this example to work properly, an active Kafka broker should be
+// Here, a `kafka:Consumer` is used as a listener to listen to a
+// given set of topic/topics. The listener uses a group of concurrent consumers within
+// the service. For this to work properly, an active Kafka broker should be
 // present.<br/><br/>
 // For more information on the underlying module, 
 // see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-group-service/kafka_consumer_group_service.description
+++ b/examples/kafka-consumer-group-service/kafka_consumer_group_service.description
@@ -3,4 +3,4 @@
 // the service. For this to work properly, an active Kafka broker should be
 // present.<br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).
+// see the [`kafka` module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-service/kafka_consumer_service.description
+++ b/examples/kafka-consumer-service/kafka_consumer_service.description
@@ -2,4 +2,4 @@
 // to a service with manual offset commits.
 // For this to work properly, an active Kafka broker should be present.<br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).
+// see the [`kafka` module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-service/kafka_consumer_service.description
+++ b/examples/kafka-consumer-service/kafka_consumer_service.description
@@ -1,7 +1,5 @@
-// This is an example, which creates a Kafka consumer used as a listener
+// Here, a Kafka consumer is used as a listener
 // to a service with manual offset commits.
-// This consumer uses the builtin `int` deserializer for the keys and the
-// builtin `string` deserializer for the values. For this example to work
-// properly, an active Kafka broker should be present.<br/><br/>
+// For this to work properly, an active Kafka broker should be present.<br/><br/>
 // For more information on the underlying module, 
 // see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-consumer-service/kafka_consumer_service.description
+++ b/examples/kafka-consumer-service/kafka_consumer_service.description
@@ -4,4 +4,4 @@
 // builtin `string` deserializer for the values. For this example to work
 // properly, an active Kafka broker should be present.<br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://docs.central.ballerina.io/ballerinax/kafka/latest).
+// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-producer-transactional/kafka_producer_transactional.description
+++ b/examples/kafka-producer-transactional/kafka_producer_transactional.description
@@ -3,4 +3,4 @@
 // this to work properly, an active Kafka broker should be present.
 // <br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).
+// see the [`kafka` module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-producer-transactional/kafka_producer_transactional.description
+++ b/examples/kafka-producer-transactional/kafka_producer_transactional.description
@@ -1,6 +1,6 @@
-// This example shows you how to do transactional message producing by sending
-// messages to kafka brokers atomically using the `kafka:Producer` object. For
-// this example to work properly, an active Kafka broker should be present.
+// This shows you how to do transactional message producing by sending
+// messages to kafka brokers atomically using the `kafka:Producer` client. For
+// this to work properly, an active Kafka broker should be present.
 // <br/><br/>
 // For more information on the underlying module, 
 // see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-producer-transactional/kafka_producer_transactional.description
+++ b/examples/kafka-producer-transactional/kafka_producer_transactional.description
@@ -1,5 +1,5 @@
 // This shows you how to do transactional message producing by sending
-// messages to kafka brokers atomically using the `kafka:Producer` client. For
+// messages to Kafka brokers atomically using the `kafka:Producer` client. For
 // this to work properly, an active Kafka broker should be present.
 // <br/><br/>
 // For more information on the underlying module, 

--- a/examples/kafka-producer-transactional/kafka_producer_transactional.description
+++ b/examples/kafka-producer-transactional/kafka_producer_transactional.description
@@ -3,4 +3,4 @@
 // this example to work properly, an active Kafka broker should be present.
 // <br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://docs.central.ballerina.io/ballerinax/kafka/latest).
+// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-producer/kafka_producer.description
+++ b/examples/kafka-producer/kafka_producer.description
@@ -2,4 +2,4 @@
 // `kafka:Producer` client. For this to work properly, an active Kafka
 // broker should be present.<br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).
+// see the [`kafka` module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-producer/kafka_producer.description
+++ b/examples/kafka-producer/kafka_producer.description
@@ -1,6 +1,5 @@
-// This is an example on how to send messages to a Kafka topic using a
-// `kafka:Producer` object. The producer is configured to send `string`
-// values and `int` keys. For this example to work properly, an active Kafka
+// This shows how to send messages to a Kafka topic using a
+// `kafka:Producer` client. For this to work properly, an active Kafka
 // broker should be present.<br/><br/>
 // For more information on the underlying module, 
 // see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).

--- a/examples/kafka-producer/kafka_producer.description
+++ b/examples/kafka-producer/kafka_producer.description
@@ -3,4 +3,4 @@
 // values and `int` keys. For this example to work properly, an active Kafka
 // broker should be present.<br/><br/>
 // For more information on the underlying module, 
-// see the [Kafka module](https://docs.central.ballerina.io/ballerinax/kafka/latest).
+// see the [Kafka module](https://lib.ballerina.io/ballerinax/kafka/latest).


### PR DESCRIPTION
# Purpose
$subject
Related to https://github.com/ballerina-platform/ballerina-dev-website/issues/3154