### PR TITLE
Add Graphql client generation tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,9 @@ subprojects {
         ballerinaStdLibs "io.ballerina.stdlib:sql-ballerina:${stdlibSqlVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:observe-ballerina:${observeVersion}"
 
+        /* Ballerina GraphQL */
+        ballerinaStdLibs "io.ballerina:graphql-tools:${graphqlVersion}"
+
         /* Ballerina OpenAPI */
         ballerinaOpenAPILibs "io.ballerina:module-ballerina-openapi:${openapiVersion}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,6 +61,9 @@ stdlibSqlVersion=1.4.0-20220324-122700-70834a7
 devToolsVersion=0.10.6
 ballerinaCommandVersion=1.3.8
 
+# GraphQL Tool
+graphqlVersion=0.0.1
+
 # OpenAPI Module
 openapiVersion=1.1.0-20220506-094700-d7761ca
 


### PR DESCRIPTION
## Purpose
> Add Graphql client generation tool to the Ballerina distribution

Resolves https://github.com/ballerina-platform/graphql-tools/issues/39

## Goals
> Add Graphql client generation tool to the Ballerina distribution

## Approach
> Add GraphQL client generation tool to build.gradle and gradle.properties

## Release note
> Add Graphql client generation tool

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11