### PR TITLE
Update GraphQL tool version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ devToolsVersion=0.10.6
 ballerinaCommandVersion=1.3.9
 
 # GraphQL Tool
-graphqlVersion=0.0.1
+graphqlVersion=0.1.0-20220510-134000-e55482f
 
 # OpenAPI Module
 openapiVersion=1.1.0-20220506-221600-4a11a5b


### PR DESCRIPTION
## Purpose
> Update GraphQL tool version

with following changes
- Removed documentation of generated records to avoid warning messages during project build
- Renamed utils template to avoid conflict with OpenAPI template in Ballerina distribution


## Goals
> Update GraphQL tool version to latest

## Approach
> Bump tool version to 0.1.0-20220510-134000-e55482f

## Release note
> Update GraphQL tool version

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > None

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.1.0-rc1.4
Operating System: Ubuntu 20.04
Java SDK: 11