### PR TITLE
Fix generating hashes in master

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256 installers/linux-deb/target/ballerina-*-linux-x64.deb
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256 installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
-          openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
+          openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}-swan-lake.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}-swan-lake.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
         uses: actions/upload-artifact@v2
@@ -101,7 +101,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Ballerina Zip Hashes
-          path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
+          path: ballerina-${{ steps.project-version.outputs.version }}-swan-lake.zip.sha256
       - name: Archive Ballerina Short Name Hashes
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ steps.version-set.outputs.longVersion }}-linux-x64.deb.sha256 installers/linux-deb/target/ballerina-*-linux-x64.deb
           openssl dgst -sha256 -out ballerina-${{ steps.version-set.outputs.longVersion }}-linux-x64.rpm.sha256 installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
-          openssl dgst -sha256 -out ballerina-${{ steps.version-set.outputs.longVersion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.version-set.outputs.version }}.zip
+          openssl dgst -sha256 -out ballerina-${{ steps.version-set.outputs.longVersion }}-swan-lake.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.version-set.outputs.version }}-swan-lake.zip
           openssl dgst -sha256 -out ballerina-${{ steps.version-set.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.version-set.outputs.sversion }}.zip
       - name: Upload zip artifacts
         uses: actions/upload-release-asset@v1
@@ -210,8 +210,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: ballerina-${{ steps.version-set.outputs.longVersion }}.zip.sha256
-          asset_path: ballerina-${{ steps.version-set.outputs.longVersion }}.zip.sha256
+          asset_name: ballerina-${{ steps.version-set.outputs.longVersion }}-swan-lake.zip.sha256
+          asset_path: ballerina-${{ steps.version-set.outputs.longVersion }}-swan-lake.zip.sha256
           asset_content_type: application/octet-stream
       - name: Upload ballerina Short Name zip Hashes
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
## Purpose
Currently with version change short version and long is the same. therefore the we need to add `-swan-lake` for creating pack.

## Goals
Fix generating hashes for ballerina zip in daily build and release workflows.

## Fixes
https://github.com/ballerina-platform/ballerina-distribution/issues/2844