### PR TITLE
Enable service and module breakpoints debugger tests

### DIFF
--- a/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
+++ b/devtools-integration-tests/src/test/java/org/ballerina/devtools/debug/ServiceDebugTest.java
@@ -33,8 +33,6 @@ import org.testng.annotations.Test;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.ballerinalang.debugger.test.utils.DebugUtils.findFreePort;
-
 /**
  * Test class for service related debug scenarios.
  */
@@ -59,7 +57,7 @@ public class ServiceDebugTest extends BaseTestCase {
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.TEST);
 
         // test for debug hits in service level variables
-        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(30000);
         Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
 
         // Timeout Exception is expected, since the service get started once the VM is resumed and resource
@@ -83,7 +81,7 @@ public class ServiceDebugTest extends BaseTestCase {
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.TEST);
 
         // Test for service call stack representation
-        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(30000);
         StackFrame[] frames = debugTestRunner.fetchStackFrames(debugHitInfo.getRight());
         debugTestRunner.assertCallStack(frames[0], "service", 20, "hello_service.bal");
     }
@@ -94,10 +92,10 @@ public class ServiceDebugTest extends BaseTestCase {
         String testSingleFileName = "hello_service.bal";
         debugTestRunner = new DebugTestRunner(testProjectName, testSingleFileName, false);
 
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 23));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 24));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.TEST);
 
-        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(30000);
         Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
     }
 

--- a/devtools-integration-tests/src/test/resources/testng.xml
+++ b/devtools-integration-tests/src/test/resources/testng.xml
@@ -20,8 +20,8 @@
 <suite name="Ballerina-Dev-Tools-Test-Suite">
     <test name="ballerina-dev-tools-tests" parallel="false">
         <classes>
-            <!--<class name="org.ballerina.devtools.debug.ModuleBreakpointTest"/>-->
-            <!--<class name="org.ballerina.devtools.debug.ServiceDebugTest"/>-->
+            <class name="org.ballerina.devtools.debug.ModuleBreakpointTest"/>
+            <class name="org.ballerina.devtools.debug.ServiceDebugTest"/>
             <!--<class name="org.ballerina.devtools.debug.ExpressionEvaluationTest"/>-->
             <class name="org.ballerina.devtools.cmd.BuildNewCommandTest"/>
         </classes>


### PR DESCRIPTION
## Purpose
Partially fixes https://github.com/ballerina-platform/ballerina-distribution/issues/3027. 
With this PR, only one test failure (`org.ballerina.devtools.debug.ExpressionEvaluationTest`) is remaining to be fixed. 

Created https://github.com/ballerina-platform/ballerina-distribution/issues/3034 to track the progress.