### PR TITLE
Make the record types used in GraphQL examples closed

### DIFF
--- a/examples/graphql-documentation/graphql_documentation.bal
+++ b/examples/graphql-documentation/graphql_documentation.bal
@@ -18,7 +18,7 @@ service /graphql on new graphql:Listener(4000) {
 # Represents a person.
 # + name - The name of the person
 # + age - The age of the person
-type Person record {
+type Person record {|
     string name;
     int age;
-};
+|};

--- a/examples/graphql-returning-record-values/graphql_returning_record_values.bal
+++ b/examples/graphql-returning-record-values/graphql_returning_record_values.bal
@@ -18,13 +18,13 @@ service /graphql on new graphql:Listener(4000) {
 }
 
 // Define the custom record types for the returning data.
-public type Person record {
+public type Person record {|
     string name;
     int age;
     Address address;
-};
-public type Address record {
+|};
+public type Address record {|
     string number;
     string street;
     string city;
-};
+|};


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3065