### PR TITLE
Update GraphQL tool version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -64,7 +64,7 @@ devToolsVersion=0.10.6
 ballerinaCommandVersion=1.3.10
 
 # GraphQL Tool
-graphqlVersion=0.1.0
+graphqlVersion=0.2.0-20220815-174800-b642ee7
 
 # OpenAPI Module
 openapiVersion=1.2.0-20220810-105800-76ae661


### PR DESCRIPTION
## Purpose
> Update GraphQL tool version

with following changes
- Update the Ballerina version to 2201.2.0-rc1.5
- Support http version 2.4.0 changes


## Goals
> Update GraphQL tool version to latest (0.2.0-20220815-174800-b642ee7)

## Approach
> Update GraphQL tool version to 0.2.0-SNAPSHOT

with following changes
- Update the Ballerina version to 2201.2.0-rc1.5
- Support http version 2.4.0 changes

## Release note
> Update GraphQL tool version

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > None

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.2.0-rc1.5
Operating System: Ubuntu 20.04
Java SDK: 11

## Related Issues
https://github.com/ballerina-platform/graphql-tools/issues/72