### PR TITLE
Update GraphQL tool version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -64,7 +64,7 @@ devToolsVersion=0.10.6
 ballerinaCommandVersion=1.3.10
 
 # GraphQL Tool
-graphqlVersion=0.2.0-20220815-174800-b642ee7
+graphqlVersion=0.2.0-20220819-144000-5532ec9
 
 # OpenAPI Module
 openapiVersion=1.2.0-20220815-131500-0ffd606


### PR DESCRIPTION
## Purpose
> Update GraphQL tool version

with following changes
- Update the Ballerina version to 2201.2.0-rc2


## Goals
> Update GraphQL tool version to latest (20220819-144000-5532ec9)

## Approach
> Update GraphQL tool version to latest (20220819-144000-5532ec9)

with following changes
- Update the Ballerina version to 2201.2.0-rc2

## Release note
> Update GraphQL tool version

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > None

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.2.0-rc2
Operating System: Ubuntu 20.04
Java SDK: 11

## Related Issues
https://github.com/ballerina-platform/graphql-tools/issues/78