### PR TITLE
Fix typo error in output of Ballerina By Example

### DIFF
--- a/examples/foreach-statement/foreach_statement.out
+++ b/examples/foreach-statement/foreach_statement.out
@@ -1,2 +1,2 @@
-bal run foreach_statement.bal
+$ bal run foreach_statement.bal
 v1:61.5 v2:61.5

--- a/examples/while-statement/while_statement.out
+++ b/examples/while-statement/while_statement.out
@@ -1,2 +1,2 @@
-bal run while_statement.bal
+$ bal run while_statement.bal
 2

--- a/gradle.properties
+++ b/gradle.properties
@@ -76,4 +76,4 @@ c2cVersion=2.3.0
 
 dataMapperVersion=2.1.0
 
-installerVersion=fd7a3686-a270-47aa-b928-d4446b53b29d
+installerVersion=8acff194-33d6-4687-bbca-63e2699a505b

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=org.ballerinalang
 # During the release workflow, the following will get bumped automatically
-version=2201.2.0-SNAPSHOT
+version=2201.2.0
 codeName=swan-lake
 ballerinaLangVersion=2201.2.0
 ballerinaJreVersion=0.8.0


### PR DESCRIPTION
## Purpose
> This PR resolves error in Foreach example at https://ballerina.io/learn/by-example/foreach-statement/ and While example at https://ballerina.io/learn/by-example/while-statement/. The **$** sign was missing in the output, due to this while clicking the copy to clipboard button the command was not copied. To fix this the **$** sign was added