### PR TITLE
Fix typo error in output of Ballerina By Example

### DIFF
--- a/examples/foreach-statement/foreach_statement.out
+++ b/examples/foreach-statement/foreach_statement.out
@@ -1,2 +1,2 @@
-bal run foreach_statement.bal
+$ bal run foreach_statement.bal
 v1:61.5 v2:61.5

--- a/examples/while-statement/while_statement.out
+++ b/examples/while-statement/while_statement.out
@@ -1,2 +1,2 @@
-bal run while_statement.bal
+$ bal run while_statement.bal
 2


### PR DESCRIPTION
## Purpose
> This PR resolves error in Foreach example at https://ballerina.io/learn/by-example/foreach-statement/ and While example at https://ballerina.io/learn/by-example/while-statement/. The $ sign was missing in the output, due to this while clicking the copy to clipboard button the command was not copied. To fix this the $ sign was added