### PR TITLE
Fix docker build in publishing release artifacts workflow

### DIFF
--- a/.github/workflows/publish-release-artifacts-1.2.x.yml
+++ b/.github/workflows/publish-release-artifacts-1.2.x.yml
@@ -91,37 +91,32 @@ jobs:
           name: Metadata JSON
           path: ${{ steps.set-version.outputs.version }}/metadata.json
 
-      - name: Process docker
-        id: process-docker
-        run: |
-          DOCKER_REPO='module-ballerina-docker'
-          echo "::set-output name=dockerRepo::$DOCKER_REPO"
-
-      - name: Checkout docker repo
-        uses: actions/checkout@v2
-        with:
-          repository: ballerina-platform/module-ballerina-docker
-          path: module-ballerina-docker
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Process docker
+        id: process-docker
+        run: |
+          git clone --single-branch --branch ballerina-1.2.x https://github.com/ballerina-platform/module-ballerina-docker
+          DOCKER_REPO='module-ballerina-docker'
+          echo "::set-output name=dockerRepo::$DOCKER_REPO"
+
+      - name: Enable experimental functions
+        run: |
+          echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
+          sudo service docker restart
+          docker version
 
       - name: Build and push docker image
         run: |
           DOCKER_REPO=${{ steps.process-docker.outputs.dockerRepo }}
           cp $VERSION/ballerina-$VERSION.zip $DOCKER_REPO/base/docker/
+
           docker build --no-cache=true --squash --build-arg BALLERINA_DIST=ballerina-$VERSION.zip -t ballerina/ballerina:$VERSION  $DOCKER_REPO/base/docker/
-          rm ballerina-$VERSION.zip
+          rm $DOCKER_REPO/base/docker/ballerina-$VERSION.zip
           docker push ballerina/ballerina:$VERSION
           docker rmi ballerina/ballerina:$VERSION
           docker image prune -f

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -98,41 +98,32 @@ jobs:
           name: Metadata JSON
           path: ${{ steps.set-version.outputs.version }}/metadata.json
 
-      - name: Process docker
-        id: process-docker
-        run: |
-          DOCKER_REPO='module-ballerina-docker'
-          echo "::set-output name=dockerRepo::$DOCKER_REPO"
-
-      - name: Checkout docker repo
-        uses: actions/checkout@v2
-        with:
-          repository: ballerina-platform/module-ballerina-docker
-          path: module-ballerina-docker
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Process docker
+        id: process-docker
+        run: |
+          git clone --single-branch --branch master https://github.com/ballerina-platform/module-ballerina-docker
+          DOCKER_REPO='module-ballerina-docker'
+          echo "::set-output name=dockerRepo::$DOCKER_REPO"
+
       - name: Enable experimental functions
         run: |
           echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
+          sudo service docker restart
+          docker version
 
       - name: Build and push docker image
         run: |
           DOCKER_REPO=${{ steps.process-docker.outputs.dockerRepo }}
           cp $VERSION/ballerina-$VERSION.zip $DOCKER_REPO/base/docker/
+
           docker build --no-cache=true --squash --build-arg BALLERINA_DIST=ballerina-$VERSION.zip -t ballerina/ballerina:$GIT_TAG  $DOCKER_REPO/base/docker/
-          rm ${dockerRepo}/base/docker/ballerina-$VERSION.zip
+          rm $DOCKER_REPO/base/docker/ballerina-$VERSION.zip
           docker push ballerina/ballerina:$GIT_TAG
           docker rmi ballerina/ballerina:$GIT_TAG
           docker image prune -f
@@ -141,8 +132,9 @@ jobs:
         run: |
           DOCKER_REPO=${{ steps.process-docker.outputs.dockerRepo }}
           cp $VERSION/ballerina-$LONG_VERSION-linux-x64.deb $DOCKER_REPO/base/devcontainer/
+
           docker build --no-cache=true --squash --build-arg BALLERINA_DIST=ballerina-$LONG_VERSION-linux-x64.deb -t ballerina/ballerina-devcontainer:$GIT_TAG $DOCKER_REPO/base/devcontainer
-          rm ${dockerRepo}/base/docker/ballerina-$LONG_VERSION-linux-x64.deb
+          rm $DOCKER_REPO/base/docker/ballerina-$LONG_VERSION-linux-x64.deb
           docker push ballerina/ballerina-devcontainer:$GIT_TAG
           docker rmi ballerina/ballerina-devcontainer:$GIT_TAG
           docker image prune -f


### PR DESCRIPTION
## Purpose
Currently docker build fails with `--squash` flag because of experimental features not being enabled in ubuntu. This will enable experimental features which will enable the `--squash` flag along with docker build as well.

## Goals
Docker build with `--squash` flag will reduce the docker image size of ballerina from ~210MB to ~160MB.


## Fixes #3221