### PR TITLE
Fix error in RabbitMQ BBE

### DIFF
--- a/examples/rabbitmq-consumer-with-client-acknowledgement/rabbitmq_consumer_with_client_acknowledgement.bal
+++ b/examples/rabbitmq-consumer-with-client-acknowledgement/rabbitmq_consumer_with_client_acknowledgement.bal
@@ -7,7 +7,8 @@ listener rabbitmq:Listener channelListener = new (rabbitmq:DEFAULT_HOST, rabbitm
 // The `ackMode` is by default rabbitmq:AUTO_ACK where messages are acknowledged
 // immediately after consuming.
 @rabbitmq:ServiceConfig {
-    queueName: "MyQueue"
+    queueName: "MyQueue",
+    autoAck: false
 }
 // Attaches the service to the listener.
 service rabbitmq:Service on channelListener {


### PR DESCRIPTION
## Purpose
`autoAck` mode should be `false` to manually acknowledge the message. Otherwise gives an error. Found when testing native-image support. 