### PR TITLE
Update Message record in RabbitMQ BBEs

### DIFF
--- a/examples/rabbitmq-consumer-with-client-acknowledgement/rabbitmq_consumer_with_client_acknowledgement.bal
+++ b/examples/rabbitmq-consumer-with-client-acknowledgement/rabbitmq_consumer_with_client_acknowledgement.bal
@@ -12,10 +12,14 @@ listener rabbitmq:Listener channelListener = new (rabbitmq:DEFAULT_HOST, rabbitm
 }
 // Attaches the service to the listener.
 service rabbitmq:Service on channelListener {
-    remote function onMessage(rabbitmq:Message message, rabbitmq:Caller caller) returns error? {
-        string messageContent = check string:fromBytes(message.content);
-        log:printInfo("Received message: " + messageContent);
+    remote function onMessage(StringMessage message, rabbitmq:Caller caller) returns error? {
+        log:printInfo("Received message: " + message.content);
         // Positively acknowledges a single message.
         check caller->basicAck();
     }
 }
+
+public type StringMessage record {|
+    *rabbitmq:AnydataMessage;
+    string content;
+|};

--- a/examples/rabbitmq-consumer/rabbitmq_consumer.bal
+++ b/examples/rabbitmq-consumer/rabbitmq_consumer.bal
@@ -11,8 +11,12 @@ listener rabbitmq:Listener channelListener = new (rabbitmq:DEFAULT_HOST, rabbitm
 }
 // Attaches the service to the listener.
 service on channelListener {
-    remote function onMessage(rabbitmq:Message message) returns error? {
-        string messageContent = check string:fromBytes(message.content);
-        log:printInfo("Received message: " + messageContent);
+    remote function onMessage(StringMessage message) returns error? {
+        log:printInfo("Received message: " + message.content);
     }
 }
+
+public type StringMessage record {|
+    *rabbitmq:AnydataMessage;
+    string content;
+|};

--- a/examples/rabbitmq-secure-connection/consumer.bal
+++ b/examples/rabbitmq-secure-connection/consumer.bal
@@ -24,8 +24,12 @@ listener rabbitmq:Listener securedEP = new(rabbitmq:DEFAULT_HOST, 5671,
 }
 // Attaches the service to the listener.
 service rabbitmq:Service on securedEP {
-    remote function onMessage(rabbitmq:Message message) returns error? {
-        string messageContent = check string:fromBytes(message.content);
-        log:printInfo("Received message: " + messageContent);
+    remote function onMessage(StringMessage message) returns error? {
+        log:printInfo("Received message: " + message.content);
     }
 }
+
+public type StringMessage record {|
+    *rabbitmq:AnydataMessage;
+    string content;
+|};

--- a/examples/rabbitmq-transaction-consumer/rabbitmq_transaction_consumer.bal
+++ b/examples/rabbitmq-transaction-consumer/rabbitmq_transaction_consumer.bal
@@ -9,11 +9,8 @@ import ballerinax/rabbitmq;
 // Attaches the service to the listener.
 service on new rabbitmq:Listener(rabbitmq:DEFAULT_HOST, rabbitmq:DEFAULT_PORT) {
     // Gets triggered when a message is received by the queue.
-    remote function onMessage(rabbitmq:Message message, rabbitmq:Caller caller) returns error? {
-        string|error messageContent = 'string:fromBytes(message.content);
-        if messageContent is string {
-            log:printInfo("The message received: " + messageContent);
-        }
+    remote function onMessage(StringMessage message, rabbitmq:Caller caller) returns error? {
+        log:printInfo("The message received: " + message.content);
         // Acknowledges a single message positively.
         // The acknowledgement gets committed upon successful execution of the transaction,
         // or will rollback otherwise.
@@ -26,3 +23,8 @@ service on new rabbitmq:Listener(rabbitmq:DEFAULT_HOST, rabbitmq:DEFAULT_PORT) {
         }
     }
 }
+
+public type StringMessage record {|
+    *rabbitmq:AnydataMessage;
+    string content;
+|};


### PR DESCRIPTION
## Purpose
Update usages of the deprecated record type `Message` in RabbitMQ BBEs and use data binding instead. 
Fixes: https://github.com/ballerina-platform/ballerina-dev-website/issues/5657