### PR TITLE
Move record and service type definitions to top in GraphQL BBEs

### DIFF
--- a/examples/graphql-client/graphql_client.bal
+++ b/examples/graphql-client/graphql_client.bal
@@ -1,14 +1,10 @@
 import ballerina/graphql;
 import ballerina/io;
 
-// User defined data types to perform client side data-binding
+// User defined data types to perform client side data-binding. This includes separate fields for
+// GraphQL errors and data.
 type ResponseWithErrors record {|
     *graphql:GenericResponseWithErrors;
-    Data data;
-|};
-
-type Response record {|
-    *graphql:GenericResponse;
     Data data;
 |};
 
@@ -16,10 +12,10 @@ type Data record {|
     Person profile;
 |};
 
-type Person record {
+type Person record {|
     string name;
     int age;
-};
+|};
 
 public function main() returns error? {
     // Creates a new client with the backend URL.
@@ -27,12 +23,11 @@ public function main() returns error? {
 
     string document = "{ profile { name, age } }";
 
-    // The `execute()` remote function of graphql:Client takes a GraphQL document
-    // as the required argument and sends a request to the specified backend URL
-    // seeking a response. On the retrieval of a successful response, the client
-    // tries to perform data binding for the user-defined data type. On failure to
-    // retrieve a successful response or when the client fails to perform data
-    // binding, a graphql:ClientError will be returned.
+    // The `execute()` remote function of the graphql:Client takes a GraphQL document as the
+    // required argument and sends a request to the specified backend URL seeking a response. On the
+    // retrieval of a successful response, the client tries to perform data binding for the
+    // user-defined data type. On failure to retrieve a successful response or when the client fails
+    // to perform data binding, a graphql:ClientError will be returned.
     ResponseWithErrors response = check graphqlClient->execute(document);
-    io:println(response.data.profile.name);
+    io:println(response.data.profile);
 }

--- a/examples/graphql-client/graphql_client.md
+++ b/examples/graphql-client/graphql_client.md
@@ -1,12 +1,17 @@
 # Client
 
-The GraphQL Client Connector can be used to connect and interact with a GraphQL server.
+The GraphQL Client can be used to connect and interact with a GraphQL server.
+
+This example shows how to send a GraphQL request and retrieve the response in a user-defined type.
+
+For more information on the underlying package, see the [GraphQL package](https://lib.ballerina.io/ballerina/graphql/latest/).
 
 ::: code graphql_client.bal :::
 
 Further, the execute method optionally takes a map of variables and an operationName in case the document contains any variables or contains more than one operation. For more information on the underlying package, see the [`graphql` package](https://lib.ballerina.io/ballerina/graphql/latest/).
 
-As the prerequisites to run the client program execute server program given in [Returning record values example](https://ballerina.io/learn/by-example/graphql-returning-record-values).
-Run the client program by executing the following command. 
+As a prerequisite to run the client program, execute a ballerina GraphQL server program given in [Returning record values example](https://ballerina.io/learn/by-example/graphql-returning-record-values).
+
+Run the client program by executing the following command.
 
 ::: out graphql_client.out :::

--- a/examples/graphql-client/graphql_client.out
+++ b/examples/graphql-client/graphql_client.out
@@ -1,4 +1,2 @@
 $ bal run graphql_client.bal
-
-# This will print the output below upon successful retrieval of response.
-Walter White
+{"name":"Walter White","age":51}

--- a/examples/graphql-context/graphql_context.bal
+++ b/examples/graphql-context/graphql_context.bal
@@ -2,6 +2,44 @@ import ballerina/graphql;
 import ballerina/http;
 import ballerina/lang.value;
 
+// Define a service class to use as an object in the GraphQL service.
+public service class Person {
+
+    private final string name;
+    private final int age;
+    private final float salary;
+
+    function init(string name, int age, float salary) {
+        self.name = name;
+        self.age = age;
+        self.salary = salary;
+    }
+
+    resource function get name() returns string {
+        return self.name;
+    }
+
+    resource function get age() returns int {
+        return self.age;
+    }
+
+    resource function get salary(graphql:Context context) returns float|error {
+
+        // Retrieve the `scope` attribute from the context.
+        value:Cloneable|isolated object {} scope = check context.get("scope");
+
+        // The `salary` value will only be returned if the `scope` is `admin`.
+        if scope is string {
+            if scope == "admin" {
+                return self.salary;
+            }
+        }
+
+        // Return an `error` if the scope mismatched.
+        return error("Permission denied");
+    }
+}
+
 @graphql:ServiceConfig {
     // Initialization of the `graphqlContext` should be provided to the `contextInit` field.
     contextInit: isolated function (http:RequestContext requestContext, http:Request request)
@@ -51,44 +89,6 @@ service /graphql on new graphql:Listener(4000) {
         }
 
         // Return an `error` if the required scope is not found.
-        return error("Permission denied");
-    }
-}
-
-// Define a service class to use as an object in the GraphQL service.
-public service class Person {
-
-    private final string name;
-    private final int age;
-    private final float salary;
-
-    function init(string name, int age, float salary) {
-        self.name = name;
-        self.age = age;
-        self.salary = salary;
-    }
-
-    resource function get name() returns string {
-        return self.name;
-    }
-
-    resource function get age() returns int {
-        return self.age;
-    }
-
-    resource function get salary(graphql:Context context) returns float|error {
-
-        // Retrieve the `scope` attribute from the context.
-        value:Cloneable|isolated object {} scope = check context.get("scope");
-
-        // The `salary` value will only be returned if the `scope` is `admin`.
-        if scope is string {
-            if scope == "admin" {
-                return self.salary;
-            }
-        }
-
-        // Return an `error` if the scope mismatched.
         return error("Permission denied");
     }
 }

--- a/examples/graphql-context/graphql_context.md
+++ b/examples/graphql-context/graphql_context.md
@@ -22,6 +22,8 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal. First, send the request with the `scope` header value set to `admin`.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_context.1.client.out :::
 
 Now, send the same document with the `scope` header value set to `user`. This will return an error in the `salary` field.

--- a/examples/graphql-directives/graphql_directives.bal
+++ b/examples/graphql-directives/graphql_directives.bal
@@ -1,19 +1,5 @@
 import ballerina/graphql;
 
-service /graphql on new graphql:Listener(4000) {
-    // Marking a field as deprecated.
-    # # Deprecated
-    # The `person` field is deprecated. Use `profile` instead.
-    @deprecated
-    resource function get person() returns Person {
-        return person;
-    }
-
-    resource function get profile() returns Person {
-        return person;
-    }
-}
-
 public type Person record {
     string name;
     int age;
@@ -48,3 +34,17 @@ Person person = {
         city: "Albuquerque"
     }
 };
+
+service /graphql on new graphql:Listener(4000) {
+    // Marking a field as deprecated.
+    # # Deprecated
+    # The `person` field is deprecated. Use `profile` instead.
+    @deprecated
+    resource function get person() returns Person {
+        return person;
+    }
+
+    resource function get profile() returns Person {
+        return person;
+    }
+}

--- a/examples/graphql-directives/graphql_directives.md
+++ b/examples/graphql-directives/graphql_directives.md
@@ -25,6 +25,8 @@ Send the following document containing the `@skip` directive to test it.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_directives.1.client.out :::
 
 Then, send the following document containing the `@include` directive.

--- a/examples/graphql-documentation/graphql_documentation.bal
+++ b/examples/graphql-documentation/graphql_documentation.bal
@@ -1,5 +1,14 @@
 import ballerina/graphql;
 
+// All the types that are used in the GraphQL service can have doc comments to add as documentation.
+# Represents a person.
+# + name - The name of the person
+# + age - The age of the person
+type Person record {|
+    string name;
+    int age;
+|};
+
 service /graphql on new graphql:Listener(4000) {
 
     // Add doc comments to reflect them in the generated GraphQL schema.
@@ -15,12 +24,3 @@ service /graphql on new graphql:Listener(4000) {
         return;
     }
 }
-
-// All the types that are used in the GraphQL service can have doc comments to add as documentation.
-# Represents a person.
-# + name - The name of the person
-# + age - The age of the person
-type Person record {|
-    string name;
-    int age;
-|};

--- a/examples/graphql-documentation/graphql_documentation.md
+++ b/examples/graphql-documentation/graphql_documentation.md
@@ -18,4 +18,6 @@ Send the following document with an introspection query to test how the document
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_documentation.client.out :::

--- a/examples/graphql-hello-world/graphql_hello_world.md
+++ b/examples/graphql-hello-world/graphql_hello_world.md
@@ -18,4 +18,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_hello_world.client.out :::

--- a/examples/graphql-hierarchical-resource-paths/graphql_hierarchical_resource_paths.md
+++ b/examples/graphql-hierarchical-resource-paths/graphql_hierarchical_resource_paths.md
@@ -18,4 +18,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_hierarchical_resource_paths.client.out :::

--- a/examples/graphql-input-objects/graphql_input_objects.bal
+++ b/examples/graphql-input-objects/graphql_input_objects.bal
@@ -1,5 +1,17 @@
 import ballerina/graphql;
 
+// Define the `NewPost` record type to use as an input object.
+public type NewPost record {|
+    string author;
+    string content;
+|};
+
+// Define the `Post` record type to use as an output object.
+public type Post record {|
+    *NewPost;
+    int id;
+|};
+
 service /graphql on new graphql:Listener(4000) {
 
     // Define an in-memory array to store the Posts
@@ -21,15 +33,3 @@ service /graphql on new graphql:Listener(4000) {
         return self.posts;
     }
 }
-
-// Define the `NewPost` record type to use as an input object.
-public type NewPost record {|
-    string author;
-    string content;
-|};
-
-// Define the `Post` record type to use as an output object.
-public type Post record {|
-    *NewPost;
-    int id;
-|};

--- a/examples/graphql-input-objects/graphql_input_objects.md
+++ b/examples/graphql-input-objects/graphql_input_objects.md
@@ -18,4 +18,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_input_objects.client.out :::

--- a/examples/graphql-input-types/graphql_input_types.md
+++ b/examples/graphql-input-types/graphql_input_types.md
@@ -20,4 +20,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_input_types.client.out :::

--- a/examples/graphql-interceptors/graphql_interceptors.md
+++ b/examples/graphql-interceptors/graphql_interceptors.md
@@ -22,4 +22,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_interceptors.client.out :::

--- a/examples/graphql-interfaces-implementing-interfaces/graphql_interfaces_implementing_interfaces.bal
+++ b/examples/graphql-interfaces-implementing-interfaces/graphql_interfaces_implementing_interfaces.bal
@@ -1,13 +1,5 @@
 import ballerina/graphql;
 
-service /graphql on new graphql:Listener(4000) {
-
-    // Returning the `Animal` type from a GraphQL resolver will identify it as an interface.
-    resource function get animals() returns Animal[] {
-        return [new Leopard(), new Elephant()];
-    }
-}
-
 // Define the `Animal` interface using a `distinct` `service` object.
 public type Animal distinct service object {
 
@@ -58,5 +50,13 @@ public distinct service class Elephant {
 
     resource function get call() returns string {
         return "Trumpet";
+    }
+}
+
+service /graphql on new graphql:Listener(4000) {
+
+    // Returning the `Animal` type from a GraphQL resolver will identify it as an interface.
+    resource function get animals() returns Animal[] {
+        return [new Leopard(), new Elephant()];
     }
 }

--- a/examples/graphql-interfaces-implementing-interfaces/graphql_interfaces_implementing_interfaces.md
+++ b/examples/graphql-interfaces-implementing-interfaces/graphql_interfaces_implementing_interfaces.md
@@ -18,4 +18,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_interfaces_implementing_interfaces.client.out :::

--- a/examples/graphql-interfaces/graphql_interfaces.bal
+++ b/examples/graphql-interfaces/graphql_interfaces.bal
@@ -1,13 +1,5 @@
 import ballerina/graphql;
 
-service /graphql on new graphql:Listener(4000) {
-
-    // Returning the `Animal` type from a GraphQL resolver will identify it as an interface.
-    resource function get animals() returns Animal[] {
-        return [new Leopard(), new Elephant()];
-    }
-}
-
 // Define the interface `Animal` using a `distinct` `service` object.
 public type Animal distinct service object {
 
@@ -39,5 +31,13 @@ public distinct service class Elephant {
 
     resource function get name() returns string {
         return "Elephas maximus maximus";
+    }
+}
+
+service /graphql on new graphql:Listener(4000) {
+
+    // Returning the `Animal` type from a GraphQL resolver will identify it as an interface.
+    resource function get animals() returns Animal[] {
+        return [new Leopard(), new Elephant()];
     }
 }

--- a/examples/graphql-interfaces/graphql_interfaces.md
+++ b/examples/graphql-interfaces/graphql_interfaces.md
@@ -18,4 +18,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_interfaces.client.out :::

--- a/examples/graphql-mutations/graphql_mutations.md
+++ b/examples/graphql-mutations/graphql_mutations.md
@@ -18,6 +18,8 @@ First, send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_mutations.1.client.out :::
 
 Now, send the following document to update the name.

--- a/examples/graphql-returning-record-values/graphql_returning_record_values.bal
+++ b/examples/graphql-returning-record-values/graphql_returning_record_values.bal
@@ -1,5 +1,17 @@
 import ballerina/graphql;
 
+// Define the custom record types for the returning data.
+public type Person record {|
+    string name;
+    int age;
+    Address address;
+|};
+public type Address record {|
+    string number;
+    string street;
+    string city;
+|};
+
 service /graphql on new graphql:Listener(4000) {
 
     // Ballerina GraphQL resolvers can return `record` values. The record will be mapped to an
@@ -16,15 +28,3 @@ service /graphql on new graphql:Listener(4000) {
         };
     }
 }
-
-// Define the custom record types for the returning data.
-public type Person record {|
-    string name;
-    int age;
-    Address address;
-|};
-public type Address record {|
-    string number;
-    string street;
-    string city;
-|};

--- a/examples/graphql-returning-record-values/graphql_returning_record_values.md
+++ b/examples/graphql-returning-record-values/graphql_returning_record_values.md
@@ -18,4 +18,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_returning_record_values.client.out :::

--- a/examples/graphql-returning-service-objects/graphql_returning_service_objects.bal
+++ b/examples/graphql-returning-service-objects/graphql_returning_service_objects.bal
@@ -1,15 +1,5 @@
 import ballerina/graphql;
 
-service /graphql on new graphql:Listener(4000) {
-
-    // This resolver returns a service type, which will be mapped to a GraphQL `OBJECT` type named
-    // `Person`. Each resource function in the service type is mapped to a field in the `OBJECT`
-    // type.
-    resource function get profile() returns Person {
-        return new("Walter White", 51);
-    }
-}
-
 // Define a service class to use as an object in the GraphQL service.
 service class Person {
     private final string name;
@@ -29,5 +19,15 @@ service class Person {
     }
     resource function get isAdult() returns boolean {
         return self.age > 21;
+    }
+}
+
+service /graphql on new graphql:Listener(4000) {
+
+    // This resolver returns a service type, which will be mapped to a GraphQL `OBJECT` type named
+    // `Person`. Each resource function in the service type is mapped to a field in the `OBJECT`
+    // type.
+    resource function get profile() returns Person {
+        return new("Walter White", 51);
     }
 }

--- a/examples/graphql-returning-service-objects/graphql_returning_service_objects.md
+++ b/examples/graphql-returning-service-objects/graphql_returning_service_objects.md
@@ -18,4 +18,6 @@ Send the following document to the GraphQL endpoint to test the service.
 
 To send the document, use the following cURL command in a separate terminal.
 
+>**Info:** You can invoke the above service via the [GraphQL client](/learn/by-example/graphql-client/).
+
 ::: out graphql_returning_service_objects.client.out :::

--- a/examples/graphql-subscriptions/graphql_subscriptions.md
+++ b/examples/graphql-subscriptions/graphql_subscriptions.md
@@ -18,6 +18,8 @@ Run the service by executing the following command.
 
 Send the following document to the GraphQL endpoint to test the service using any GraphQL client that supports subscriptions to test the service.
 
+>**Info:** You can invoke the above service via the [GraphiQL](/learn/by-example/graphql-graphiql/).
+
 ::: code graphql_subscriptions.graphql :::
 
 It should return the following values.


### PR DESCRIPTION
## Purpose
To make all the BBEs consistent, the type definitions including record and service types are moved to the top of the bal file.