### PR TITLE
Update GraphQL spec links in BBEs

### DIFF
--- a/examples/graphql-client-security-basic-auth/graphql_client_security_basic_auth.md
+++ b/examples/graphql-client-security-basic-auth/graphql_client_security_basic_auth.md
@@ -14,4 +14,4 @@ Run the client program by executing the following command.
 ## Related links
 - [`graphql:CredentialsConfig` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/CredentialsConfig)
 - [`auth` module - API documentation](https://lib.ballerina.io/ballerina/auth/latest/)
-- [GraphQL client basic authentication - Specification](/spec/graphql/#1121-basic-authentication)
+- [GraphQL client basic authentication - Specification](/spec/graphql/#1221-basic-authentication)

--- a/examples/graphql-client-security-mutual-ssl/graphql_client_security_mutual_ssl.md
+++ b/examples/graphql-client-security-mutual-ssl/graphql_client_security_mutual_ssl.md
@@ -13,4 +13,4 @@ Run the client program by executing the following command.
 
 ## Related links
 - [`graphql:ClientSecureSocket` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/ClientSecureSocket)
-- [GraphQL client mutual SSL - Specification](/spec/graphql/#11322-mutual-ssl)
+- [GraphQL client mutual SSL - Specification](/spec/graphql/#12322-mutual-ssl)

--- a/examples/graphql-client-security-oauth2-password-grant-type/graphql_client_security_oauth2_password_grant_type.md
+++ b/examples/graphql-client-security-oauth2-password-grant-type/graphql_client_security_oauth2_password_grant_type.md
@@ -14,4 +14,4 @@ Run the client program by executing the command below.
 ## Related links
 - [`graphql:OAuth2PasswordGrantConfig` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/OAuth2PasswordGrantConfig)
 - [`oauth2` module - API documentation](https://lib.ballerina.io/ballerina/oauth2/latest/)
-- [GraphQL client OAuth2 password grant type - Specification](/spec/graphql/#11242-password-grant-type)
+- [GraphQL client OAuth2 password grant type - Specification](/spec/graphql/#12242-password-grant-type)

--- a/examples/graphql-client-security-self-signed-jwt-authentication/graphql_client_security_self_signed_jwt_authentication.md
+++ b/examples/graphql-client-security-self-signed-jwt-authentication/graphql_client_security_self_signed_jwt_authentication.md
@@ -14,4 +14,4 @@ Run the client program by executing the command below.
 ## Related links
 - [`graphql:JwtIssuerConfig` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/JwtIssuerConfig)
 - [`jwt` module - API documentation](https://lib.ballerina.io/ballerina/jwt/latest/)
-- [GraphQL client self signed JWT authentication - Specification](/spec/graphql/#1123-self-signed-jwt-authentication)
+- [GraphQL client self signed JWT authentication - Specification](/spec/graphql/#1223-self-signed-jwt-authentication)

--- a/examples/graphql-client-security-ssl-tls/graphql_client_security_ssl_tls.md
+++ b/examples/graphql-client-security-ssl-tls/graphql_client_security_ssl_tls.md
@@ -13,4 +13,4 @@ Run the client program by executing the following command.
 
 ## Related links
 - [`graphql:ClientSecureSocket` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/ClientSecureSocket)
-- [GraphQL client SSL/TLS - Specification](/spec/graphql/#11321-ssltls)
+- [GraphQL client SSL/TLS - Specification](/spec/graphql/#12321-ssltls)

--- a/examples/graphql-graphiql/graphql_graphiql.md
+++ b/examples/graphql-graphiql/graphql_graphiql.md
@@ -17,4 +17,5 @@ To access the GraphiQL client, open a browser and access `http://localhost:9090/
 ## Related links
 - [`graphql:ServiceConfig` annotation - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/annotations#ServiceConfig)
 - [`graphql:GraphiQL` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/Graphiql)
-- [GraphQL GraphiQL client - Specification](/spec/graphql/#915-graphiql-configurations)
+- [GraphQL GraphiQL client - Configuration](/spec/graphql/#1015-graphiql-configurations)
+- [GraphQL GraphiQL client - Specification](/spec/graphql/#131-graphiql-client)

--- a/examples/graphql-interceptors/graphql_interceptors.md
+++ b/examples/graphql-interceptors/graphql_interceptors.md
@@ -22,4 +22,4 @@ To send the document, use the following cURL command in a separate terminal.
 
 ## Related links
 - [`graphql:Interceptor` object - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/objectTypes/Interceptor)
-- [GraphQL interceptors - Specification](/spec/graphql/#10-interceptors)
+- [GraphQL interceptors - Specification](/spec/graphql/#11-interceptors)

--- a/examples/graphql-service-basic-auth-file-user-store/graphql_service_basic_auth_file_user_store.md
+++ b/examples/graphql-service-basic-auth-file-user-store/graphql_service_basic_auth_file_user_store.md
@@ -20,4 +20,4 @@ Run the service by executing the command below.
 - [`graphql:ServiceConfig` annotation - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/annotations#ServiceConfig)
 - [`graphql:FileUserStoreConfigWithScopes` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/FileUserStoreConfigWithScopes)
 - [`auth` module - API documentation](https://lib.ballerina.io/ballerina/auth/latest/)
-- [GraphQL service basic authentication - file user store - Specification](/spec/graphql/#11111-basic-authentication---file-user-store)
+- [GraphQL service basic authentication - file user store - Specification](/spec/graphql/#12111-basic-authentication---file-user-store)

--- a/examples/graphql-service-basic-auth-ldap-user-store/graphql_service_basic_auth_ldap_user_store.md
+++ b/examples/graphql-service-basic-auth-ldap-user-store/graphql_service_basic_auth_ldap_user_store.md
@@ -19,4 +19,4 @@ Run the service by executing the command below.
 - [`graphql:ServiceConfig` annotation - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/annotations#ServiceConfig)
 - [`graphql:LdapUserStoreConfigWithScopes` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/LdapUserStoreConfigWithScopes)
 - [`auth` module - API documentation](https://lib.ballerina.io/ballerina/auth/latest/)
-- [GraphQL service basic authentication - LDAP user store - Specification](/spec/graphql/#11112-basic-authentication---ldap-user-store)
+- [GraphQL service basic authentication - LDAP user store - Specification](/spec/graphql/#12112-basic-authentication---ldap-user-store)

--- a/examples/graphql-service-jwt-auth/graphql_service_jwt_auth.md
+++ b/examples/graphql-service-jwt-auth/graphql_service_jwt_auth.md
@@ -14,4 +14,4 @@ Run the service by executing the command below.
 - [`graphql:ServiceConfig` annotation - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/annotations#ServiceConfig)
 - [`graphql:JwtValidatorConfigWithScopes` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/JwtValidatorConfigWithScopes)
 - [`jwt` module - API documentation](https://lib.ballerina.io/ballerina/jwt/latest/)
-- [GraphQL service JWT authentication - Specification](/spec/graphql/#11113-jwt-authentication)
+- [GraphQL service JWT authentication - Specification](/spec/graphql/#12113-jwt-authentication)

--- a/examples/graphql-service-mutual-ssl/graphql_service_mutual_ssl.md
+++ b/examples/graphql-service-mutual-ssl/graphql_service_mutual_ssl.md
@@ -13,4 +13,4 @@ Run the service by executing the command below.
 ## Related links
 - [`graphql:ListenerConfiguration` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/ListenerConfiguration)
 - [`graphql:ListenerSecureSocket` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/ListenerSecureSocket)
-- [GraphQL service mutual SSL - Specification](/spec/graphql/#11312-mutual-ssl)
+- [GraphQL service mutual SSL - Specification](/spec/graphql/#12312-mutual-ssl)

--- a/examples/graphql-service-oauth2/graphql_service_oauth2.md
+++ b/examples/graphql-service-oauth2/graphql_service_oauth2.md
@@ -17,4 +17,4 @@ Run the service by executing the command below.
 - [`graphql:ServiceConfig` annotation - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/annotations#ServiceConfig)
 - [`graphql:OAuth2IntrospectionConfigWithScopes` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/OAuth2IntrospectionConfigWithScopes)
 - [`oauth2` module - API documentation](https://lib.ballerina.io/ballerina/oauth2/latest/)
-- [GraphQL service OAuth2 - Specification](/spec/graphql/#11114-oauth2)
+- [GraphQL service OAuth2 - Specification](/spec/graphql/#12114-oauth2)

--- a/examples/graphql-service-ssl-tls/graphql_service_ssl_tls.md
+++ b/examples/graphql-service-ssl-tls/graphql_service_ssl_tls.md
@@ -13,4 +13,4 @@ Run the service by executing the command below.
 ## Related links
 - [`graphql:ListenerConfiguration` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/ListenerConfiguration)
 - [`graphql:ListenerSecureSocket` record - API documentation](https://lib.ballerina.io/ballerina/graphql/latest/records/ListenerSecureSocket)
-- [GraphQL service SSL/TLS - Specification](/spec/graphql/#11311-ssltls)
+- [GraphQL service SSL/TLS - Specification](/spec/graphql/#12311-ssltls)


### PR DESCRIPTION
## Purpose
GraphQL spec has been updated recently. Hence some of the links will not work properly. This PR will update those links.