### PR TITLE
Update logic to provide release note for official Releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -125,11 +125,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           gh repo view ballerina-platform/ballerina-dev-website -b release-2201.7.0 --json url --jq '.clone_url'
-          gh api repos/ballerina-platform/ballerina-dev-website/contents/downloads/verification-notes/release-artfiacts-verification.md?ref=release-2201.7.0 -H 'Accept: application/vnd.github.v3.raw' > release_notes.md
+          gh api repos/ballerina-platform/ballerina-dev-website/contents/downloads/verification-notes/release-artifacts-verification.md?ref=release-2201.7.0 -H 'Accept: application/vnd.github.v3.raw' > release_notes.md
       - name: Update Markdown file
         run: |
           branchName=$(echo ${{ github.ref }} | cut -d'/' -f3)
-          if ${{ github.event.inputs.isPreRelease }} == 'true'; then echo "" > release_notes.md; else sed -i 's/{{ version }}/${{ steps.version-set.outputs.taggedVersion }}/g' release_notes.md; sed -i 's/{{ branch }}/$branchName/g' release_notes.md; fi
+          if ${{ github.event.inputs.isPreRelease }} == 'true'; then 
+            echo "" > release_notes.md; 
+          else sed -i 's/{{ version }}/${{ steps.version-set.outputs.taggedVersion }}/g' release_notes.md; sed -i 's/{{ branch }}/$branchName/g' release_notes.md; fi
       - name: Read release notes from file
         id: release_notes
         uses: actions/github-script@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -125,7 +125,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           gh repo view ballerina-platform/ballerina-dev-website -b release-2201.7.0 --json url --jq '.clone_url'
-          gh api repos/ballerina-platform/ballerina-dev-website/contents/downloads/verification-notes/release-artifacts-verification.md?ref=release-2201.7.0 -H 'Accept: application/vnd.github.v3.raw' > release_notes.md
+          gh api repos/ballerina-platform/ballerina-dev-website/contents/downloads/verification-notes/release-artfiacts-verification.md?ref=release-2201.7.0 -H 'Accept: application/vnd.github.v3.raw' > release_notes.md
       - name: Update Markdown file
         run: |
           branchName=$(echo ${{ github.ref }} | cut -d'/' -f3)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -128,7 +128,8 @@ jobs:
           gh api repos/ballerina-platform/ballerina-dev-website/contents/downloads/verification-notes/release-artfiacts-verification.md?ref=release-2201.7.0 -H 'Accept: application/vnd.github.v3.raw' > release_notes.md
       - name: Update Markdown file
         run: |
-          sed -i 's/{{ version }}/${{ steps.version-set.outputs.taggedVersion }}/g' release_notes.md
+          branchName=$(echo ${{ github.ref }} | cut -d'/' -f3)
+          if ${{ github.event.inputs.isPreRelease }} == 'true'; then echo "" > release_notes.md; else sed -i 's/{{ version }}/${{ steps.version-set.outputs.taggedVersion }}/g' release_notes.md; sed -i 's/{{ branch }}/$branchName/g' release_notes.md; fi
       - name: Read release notes from file
         id: release_notes
         uses: actions/github-script@v4


### PR DESCRIPTION
## Purpose

The `update markdown` logic has been updated to now only update the markdown file for official releases, in the case of `pre-releases` the markdown will be empty.