### PR TITLE
Integrate `Notation` to sign Ballerina Images

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -7,6 +7,9 @@ on:
         description: 'Release Version e.g., 2201.1.1, 2201.1.1-rc1'
         default: '2201.1.1'
         required: true
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ballerina
 
 jobs:
   publish-artifacts:
@@ -133,12 +136,11 @@ jobs:
         run: |
           DOCKER_REPO=${{ steps.process-docker.outputs.dockerRepo }}
           cp $VERSION/ballerina-$VERSION.zip $DOCKER_REPO/base/docker/
-
+          
           docker build --no-cache=true --squash --build-arg BALLERINA_DIST=ballerina-$VERSION.zip -t ballerina/ballerina:$GIT_TAG  $DOCKER_REPO/base/docker/
           rm $DOCKER_REPO/base/docker/ballerina-$VERSION.zip
           docker push ballerina/ballerina:$GIT_TAG
-          docker rmi ballerina/ballerina:$GIT_TAG
-          docker image prune -f
+          
 
       - name: Build and push dev container
         run: |
@@ -149,6 +151,42 @@ jobs:
           rm $DOCKER_REPO/base/devcontainer/ballerina-$LONG_VERSION-linux-x64.deb
           docker push ballerina/ballerina-devcontainer:$GIT_TAG
           docker rmi ballerina/ballerina-devcontainer:$GIT_TAG
+          docker image prune -f
+
+      - name: azure-resource-login
+        uses: Azure/azure-resource-login-action@v1.0.0
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Setup Notation with azure-kv plugin
+        uses: Duffney/setup-notation@v1.0.0
+        with:
+          version: 1.0.0-rc.7
+          key_name: ${{ secrets.AZURE_KEY_NAME }}
+          certificate_key_id: ${{ secrets.AZURE_KEY_ID }}
+          plugin_name: notation-azure-kv
+          plugin_version:  0.5.0-rc.1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image to Github Container Registry
+        run: |
+          docker tag ballerina/ballerina:$GIT_TAG ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
+          docker push ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
+      
+      - name: Verify key generation
+        run: notation key list 
+     
+      - name: Sign the published Docker image
+        run: | 
+          notation sign --key ${{ secrets.AZURE_KEY_NAME }} ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
+          docker rmi ballerina/ballerina:$GIT_TAG
+          docker rmi ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
           docker image prune -f
 
       - name: Publish Artifacts

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -9,6 +9,7 @@ on:
         required: true
 env:
   REGISTRY: ghcr.io
+  ORGNAME: ballerina-platform 
   IMAGE_NAME: ballerina
 
 jobs:
@@ -141,7 +142,6 @@ jobs:
           rm $DOCKER_REPO/base/docker/ballerina-$VERSION.zip
           docker push ballerina/ballerina:$GIT_TAG
           
-
       - name: Build and push dev container
         run: |
           DOCKER_REPO=${{ steps.process-docker.outputs.dockerRepo }}
@@ -171,22 +171,22 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.ORGNAME }}
+          password: ${{ secrets.BALLERINA_BOT_TOKEN }}
 
       - name: Push image to Github Container Registry
         run: |
-          docker tag ballerina/ballerina:$GIT_TAG ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
-          docker push ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
+          docker tag ballerina/ballerina:$GIT_TAG ${{ env.REGISTRY }}/${{ env.ORGNAME }}/${{ env.IMAGE_NAME }}:$GIT_TAG
+          docker push ${{ env.REGISTRY }}/${{ env.ORGNAME }}/${{ env.IMAGE_NAME }}:$GIT_TAG
       
       - name: Verify key generation
         run: notation key list 
      
       - name: Sign the published Docker image
         run: | 
-          notation sign --key ${{ secrets.AZURE_KEY_NAME }} ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
+          notation sign --key ${{ secrets.AZURE_KEY_NAME }} ${{ env.REGISTRY }}/${{ env.ORGNAME }}/${{ env.IMAGE_NAME }}:$GIT_TAG
           docker rmi ballerina/ballerina:$GIT_TAG
-          docker rmi ${{ env.REGISTRY }}/ballerina-platform/${{ env.IMAGE_NAME }}:$GIT_TAG
+          docker rmi ${{ env.REGISTRY }}/${{ env.ORGNAME }}/${{ env.IMAGE_NAME }}:$GIT_TAG
           docker image prune -f
 
       - name: Publish Artifacts


### PR DESCRIPTION
## Purpose

Publish the Ballerina Image to Github Container Registry and sign the Ballerina Image using `Notary Project's Notation Tool`.

There currently is no Official Github Action for `Notation` Tool, therefore I've referred to the prototype `Notation` Action as mentioned [here](https://github.com/duffney/setup-notation). The details for the official Github Action can be tracked via this [issue](https://github.com/notaryproject/.github/issues/30)

Fixes #4636 

**Note:** Secrets have been added in the workflow, the format of each `secret` is mentioned:
Azure Credentials for Resource login - `${{ secrets.AZURE_CREDENTIALS }}` - [setup credentials as follows](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#use-the-azure-login-action-with-a-service-principal-secret)
Signing Key Name -`${{ secrets.AZURE_KEY_NAME }}`  - `<KEY_NAME>`
Certificate ID - `${{ secrets.AZURE_KEY_ID }}` - `https://<key_vault_name>.vault.azure.net/certificates/xxxxxx/xxxxxxxxxxxxxxxxxxxxxxx`