### PR TITLE
Skip CVE-2024-21742 vulnerability for 2201.8.6 release

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,3 +9,5 @@ CVE-2023-4586
 CVE-2020-8908
 CVE-2024-25710
 CVE-2024-26308
+# apache-mime4j-core dependency vulerability (remove once the fixed version for Axiom API is delivered)
+CVE-2024-21742


### PR DESCRIPTION
## Purpose
There is a security vulnerability (CVE-2024-21742) in `apache-mime4j-core` 0.8.6 version and it is used as a dependency for `axiom-api` 1.4.0 version. Since there is no new version with a fix for this in `axiom-api` library, the
`CVE-2024-21742` vulnerability is skipped for the moment.
Once the `axiom-api` is updated with `apache-mime4j-core:0.8.10` version, it should be updated in the lang repo and remove this vulnerability from the `.trivyignore` file
