### PR TITLE
[2201.8.x] Temporary disable output verification for `sequence-diagrams` BBE

### DIFF
--- a/examples/index.json
+++ b/examples/index.json
@@ -1387,7 +1387,7 @@
         "name": "Sequence diagrams",
         "url": "sequence-diagrams",
         "verifyBuild": true,
-        "verifyOutput": true,
+        "verifyOutput": false,
         "isLearnByExample": true
       },
       {


### PR DESCRIPTION
## Purpose
Sending same PR #5273 to 8.x. 

Verification is failing due to url in the bbe is giving 503 http error code.