### PR TITLE
Bump persist tools version with latest googlesheets version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -71,7 +71,7 @@ stdlibGraphqlVersion=1.12.0-20240410-210000-f6ca9b0
 stdlibSqlVersion=1.13.0-20240410-205900-22f19c6
 
 # Persist Tool
-persistToolVersion=1.3.0-20240410-230800-30e25cd
+persistToolVersion=1.3.0-20240412-140700-c1a147b
 
 # Dev Tools
 devToolsVersion=1.4.0-20240410-233400-7586fc7


### PR DESCRIPTION
## Purpose
$subject, please. This is to bump the persist tools version with the latest `persist-googlesheets` version and fix disabled test cases.