### PR TITLE
Disable output verification of Avro BBE

### DIFF
--- a/examples/index.json
+++ b/examples/index.json
@@ -4234,7 +4234,7 @@
         "name": "Serialization/Deserialization",
         "url": "avro-serdes",
         "verifyBuild": true,
-        "verifyOutput": true,
+        "verifyOutput": false,
         "disablePlayground": true,
         "isLearnByExample": false
       }


### PR DESCRIPTION
## Purpose
> Fix the build failure https://github.com/ballerina-platform/ballerina-distribution/actions/runs/9102412265/job/25021940100 which occurs due to log output mismatch.

```
Failed due to output did not match. Line 0: ballerina/avro:1.0.0 [central.ballerina.io ->/home/runner/.ballerina/repositories/central.ballerina.io/bala/ballerina/avro/1.0.0]   17% [>
ballerina/avro:1.0.0 [central.ballerina.io ->/home/runner/.ballerina/repositories/central.ballerina.io/bala/ballerina/avro/1.0.0]  100% [
Failed due to output did not match. Line 1: ballerina/avro:1.0.0 pulled from central successfully

```