### PR TITLE
Update the deprecated artifact action version in workflow files to v4

### DIFF
--- a/.github/workflows/daily-build-2201.10.x.yml
+++ b/.github/workflows/daily-build-2201.10.x.yml
@@ -62,57 +62,57 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -331,12 +331,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -381,12 +381,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
       - name: Archive MacOS-ARM pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256
       - name: Archive MacOS-ARM pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ARM pkg
           path: installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -429,12 +429,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-2201.3.x.yml
+++ b/.github/workflows/daily-build-2201.3.x.yml
@@ -62,52 +62,52 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -324,12 +324,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -379,12 +379,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-2201.4.x.yml
+++ b/.github/workflows/daily-build-2201.4.x.yml
@@ -62,52 +62,52 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -325,12 +325,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -380,12 +380,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-2201.5.x.yml
+++ b/.github/workflows/daily-build-2201.5.x.yml
@@ -62,57 +62,57 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -330,12 +330,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -380,12 +380,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
       - name: Archive MacOS-ARM pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256
       - name: Archive MacOS-ARM pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ARM pkg
           path: installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -422,12 +422,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-2201.6.x.yml
+++ b/.github/workflows/daily-build-2201.6.x.yml
@@ -62,57 +62,57 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -330,12 +330,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -380,12 +380,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
       - name: Archive MacOS-ARM pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256
       - name: Archive MacOS-ARM pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ARM pkg
           path: installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -428,12 +428,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-2201.7.x.yml
+++ b/.github/workflows/daily-build-2201.7.x.yml
@@ -62,57 +62,57 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -331,12 +331,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -381,12 +381,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
       - name: Archive MacOS-ARM pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256
       - name: Archive MacOS-ARM pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ARM pkg
           path: installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -429,12 +429,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-2201.8.x.yml
+++ b/.github/workflows/daily-build-2201.8.x.yml
@@ -62,57 +62,57 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -331,12 +331,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -381,12 +381,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
       - name: Archive MacOS-ARM pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256
       - name: Archive MacOS-ARM pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ARM pkg
           path: installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -429,12 +429,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-2201.9.x.yml
+++ b/.github/workflows/daily-build-2201.9.x.yml
@@ -62,57 +62,57 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -331,12 +331,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -381,12 +381,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
       - name: Archive MacOS-ARM pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256
       - name: Archive MacOS-ARM pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ARM pkg
           path: installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -429,12 +429,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-build-editor.yml
+++ b/.github/workflows/daily-build-editor.yml
@@ -94,32 +94,32 @@ jobs:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -61,57 +61,57 @@ jobs:
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.version }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.version }}.zip
           openssl dgst -sha256 -out ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256 ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip
       - name: Archive Linux deb Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux deb Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.deb.sha256
       - name: Archive Linux rpm Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux rpm Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}-linux-x64.rpm.sha256
       - name: Archive Ballerina Zip Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Zip Hashes
           path: ballerina-${{ steps.project-version.outputs.version }}.zip.sha256
       - name: Archive Ballerina Short Name Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name Hashes
           path: ballerina-${{ steps.project-version.outputs.sversion }}.zip.sha256
@@ -335,12 +335,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-x64.pkg
       - name: Archive MacOS pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-x64.pkg.sha256
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -385,12 +385,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256 installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
       - name: Archive MacOS-ARM pkg Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM pkg Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-macos-arm-x64.pkg.sha256
       - name: Archive MacOS-ARM pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ARM pkg
           path: installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -431,12 +431,12 @@ jobs:
         run: |
           openssl dgst -sha256 -out ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256 w\target\msi\ballerina-*-windows-x64.msi
       - name: Archive Windows msi Hashes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows msi Hashes
           path: ballerina-${{ needs.ubuntu-build.outputs.project-version }}-windows-x64.msi.sha256
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/language_server_simulator_fhir.yml
+++ b/.github/workflows/language_server_simulator_fhir.yml
@@ -53,14 +53,14 @@ jobs:
           ./mat/ParseHeapDump.sh ./dump.hprof org.eclipse.mat.api:suspects
 
       - name: Upload Heap Dumps
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: heap_dump-${{ matrix.branch }}.hprof
           path: '*.hprof'
 
       - name: Upload Leaks Suspects
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Leak_Suspects-${{ matrix.branch }}

--- a/.github/workflows/language_server_simulator_nballerina.yml
+++ b/.github/workflows/language_server_simulator_nballerina.yml
@@ -53,14 +53,14 @@ jobs:
           ./mat/ParseHeapDump.sh ./dump.hprof org.eclipse.mat.api:suspects
 
       - name: Upload Heap Dumps
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: heap_dump-${{ matrix.branch }}.hprof
           path: '*.hprof'
 
       - name: Upload Leaks Suspects
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Leak_Suspects-${{ matrix.branch }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,27 +51,27 @@ jobs:
           githubAccessToken: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon --continue -x test
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina/build/distributions/ballerina-${{ steps.project-version.outputs.sversion }}.zip
       - name: Archive Linux installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux installer ZIP
           path: ballerina/build/distributions/ballerina-*-linux.zip
       - name: Archive MacOS installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS installer ZIP
           path: ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina/build/distributions/ballerina-*-windows.zip

--- a/.github/workflows/publish-release-artifacts-1.2.x.yml
+++ b/.github/workflows/publish-release-artifacts-1.2.x.yml
@@ -88,7 +88,7 @@ jobs:
           echo } >> $fileName
 
       - name: Archive metadata json
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Metadata JSON
           path: ${{ steps.set-version.outputs.version }}/metadata.json

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -106,7 +106,7 @@ jobs:
           echo "}" >> $fileName
 
       - name: Archive metadata json
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Metadata JSON
           path: ${{ steps.set-version.outputs.version }}/metadata.json


### PR DESCRIPTION
## Purpose
GitHub has deprecated the artifact action v1 and v2 which leads to build failures in release workflows.
https://github.com/ballerina-platform/ballerina-release/actions/runs/10826921877/job/30038931866

**Deprecation notice:**  https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions
