### PR TITLE
Update the download artifact action version to v4 in workflow files

### DIFF
--- a/.github/workflows/daily-build-2201.3.x.yml
+++ b/.github/workflows/daily-build-2201.3.x.yml
@@ -283,7 +283,7 @@ jobs:
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - name: Download Ballerina rpm Installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Linux Installer rpm
       - name: Install Ballerina RPM
@@ -311,7 +311,7 @@ jobs:
         with:
           ref: 2201.3.x
       - name: Download MacOS Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS Installer ZIP
       - name: Create macos-pkg
@@ -363,7 +363,7 @@ jobs:
       - name: Install GUID Generator
         run: dotnet tool install -g dotnet-guid --version 0.5.2
       - name: Download Windows Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Windows Installer ZIP
       - name: Create windows-msi

--- a/.github/workflows/daily-build-2201.4.x.yml
+++ b/.github/workflows/daily-build-2201.4.x.yml
@@ -283,7 +283,7 @@ jobs:
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - name: Download Ballerina rpm Installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Linux Installer rpm
       - name: Install Ballerina RPM
@@ -312,7 +312,7 @@ jobs:
         with:
           ref: 2201.4.x
       - name: Download MacOS Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS Installer ZIP
       - name: Create macos-pkg
@@ -364,7 +364,7 @@ jobs:
       - name: Install GUID Generator
         run: dotnet tool install -g dotnet-guid --version 0.5.2
       - name: Download Windows Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Windows Installer ZIP
       - name: Create windows-msi

--- a/.github/workflows/daily-build-2201.5.x.yml
+++ b/.github/workflows/daily-build-2201.5.x.yml
@@ -288,7 +288,7 @@ jobs:
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - name: Download Ballerina rpm Installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Linux Installer rpm
       - name: Install Ballerina RPM
@@ -317,7 +317,7 @@ jobs:
         with:
           ref: 2201.5.x
       - name: Download MacOS Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS Installer ZIP
       - name: Create macos-pkg
@@ -367,7 +367,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Download MacOS-ARM Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
       - name: Create macos-arm-pkg
@@ -406,7 +406,7 @@ jobs:
       - name: Install GUID Generator
         run: dotnet tool install -g dotnet-guid --version 0.5.2
       - name: Download Windows Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Windows Installer ZIP
       - name: Create windows-msi

--- a/.github/workflows/daily-build-2201.6.x.yml
+++ b/.github/workflows/daily-build-2201.6.x.yml
@@ -288,7 +288,7 @@ jobs:
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - name: Download Ballerina rpm Installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Linux Installer rpm
       - name: Install Ballerina RPM
@@ -317,7 +317,7 @@ jobs:
         with:
           ref: 2201.6.x
       - name: Download MacOS Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS Installer ZIP
       - name: Create macos-pkg
@@ -367,7 +367,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Download MacOS-ARM Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
       - name: Create macos-arm-pkg
@@ -414,7 +414,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
         shell: bash
       - name: Download Windows Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Windows Installer ZIP
       - name: Create windows-msi

--- a/.github/workflows/daily-build-2201.7.x.yml
+++ b/.github/workflows/daily-build-2201.7.x.yml
@@ -288,7 +288,7 @@ jobs:
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - name: Download Ballerina rpm Installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Linux Installer rpm
       - name: Install Ballerina RPM
@@ -317,7 +317,7 @@ jobs:
         with:
           ref: 2201.7.x
       - name: Download MacOS Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS Installer ZIP
       - name: Create macos-pkg
@@ -367,7 +367,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Download MacOS-ARM Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
       - name: Create macos-arm-pkg
@@ -414,7 +414,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
         shell: bash
       - name: Download Windows Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Windows Installer ZIP
       - name: Create windows-msi

--- a/.github/workflows/daily-build-2201.8.x.yml
+++ b/.github/workflows/daily-build-2201.8.x.yml
@@ -288,7 +288,7 @@ jobs:
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - name: Download Ballerina rpm Installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Linux Installer rpm
       - name: Install Ballerina RPM
@@ -317,7 +317,7 @@ jobs:
         with:
           ref: 2201.8.x
       - name: Download MacOS Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS Installer ZIP
       - name: Create macos-pkg
@@ -367,7 +367,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17.0.7'
       - name: Download MacOS-ARM Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
       - name: Create macos-arm-pkg
@@ -414,7 +414,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
         shell: bash
       - name: Download Windows Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Windows Installer ZIP
       - name: Create windows-msi

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -283,7 +283,7 @@ jobs:
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - name: Download Ballerina rpm Installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Linux Installer rpm
       - name: Install Ballerina RPM
@@ -315,7 +315,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17.0.7'
       - name: Download MacOS Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS Installer ZIP
       - name: Create macos-pkg
@@ -365,7 +365,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17.0.7'
       - name: Download MacOS-ARM Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
       - name: Create macos-arm-pkg
@@ -410,7 +410,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
         shell: bash
       - name: Download Windows Intaller Zip
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Windows Installer ZIP
       - name: Create windows-msi


### PR DESCRIPTION
## Purpose
GitHub has deprecated the download and upload artifact action v1 and v2 which leads to build failures in release workflows.
https://github.com/ballerina-platform/ballerina-release/actions/runs/10826921877/job/30038931866

**Deprecation notice:**  https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions
