### PR TITLE
Only consider high and critical Trivy vulnerabilities

### DIFF
--- a/.github/workflows/publish_release_bi.yml
+++ b/.github/workflows/publish_release_bi.yml
@@ -129,6 +129,7 @@ jobs:
           format: 'table'
           exit-code: '1'
           timeout: "10m0s"
+          severity: 'CRITICAL,HIGH'
       - name: cosign-installer
         uses: sigstore/cosign-installer@v3.5.0
       - name: Set up Node.js


### PR DESCRIPTION
## Purpose

The Kola releases follow a rolling update for the testing period. Therefore, this release shouldn't be affected by low vulnerabilities.