### PR TITLE
Update the artifacts copying related to LS extensions

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -249,38 +249,12 @@ task copyOtherRepos(type: Copy) {
     }
 
     /* Language Server Extension Artifacts */
-    def generatorNames = [
-        "architecture-model-generator",
-        "graphql-model-generator",
-        "flow-model-generator",
-        "sequence-model-generator",
-        "trigger-model-generator"
-    ]
-    
     configurations.devTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         def artifactExtractedPath = "${buildDir}/target/extracted-distributions/${artifact.name}-zip"
-        generatorNames.each { generatorName ->
-            from("${artifactExtractedPath}/${generatorName}/libs") {
-                into "bre/lib/"
-            }
-            from("${artifactExtractedPath}/${generatorName}/ls-libs") {
-                into "lib/tools/lang-server/lib/"
-            }
+        from("${artifactExtractedPath}/ls-extensions/bre-libs") {
+            into "bre/lib/"
         }
-    }
-
-    /* Service Model Generator Artifacts */
-    configurations.devTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
-        from("${artifactExtractedPath}/service-model-generator/ls-libs") {
-            into "lib/tools/lang-server/lib/"
-        }
-    }
-
-    /* Test Manager Service Artifacts */
-    configurations.devTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
-        from("${artifactExtractedPath}/test-manager-service/ls-libs") {
+        from("${artifactExtractedPath}/ls-extensions/ls-libs") {
             into "lib/tools/lang-server/lib/"
         }
     }


### PR DESCRIPTION
## Purpose
The responsibility for deciding which JAR files belong in the bre-lib versus the ls-libs is now delegated to the dev-tools. This removes the necessity to update the distribution configurations every time there is an update to the ls extension