### PR TITLE
Use data.xmldata package for deprecated xmldata package

### DIFF
--- a/examples/xml-from-json-conversion/xml_from_json_conversion.bal
+++ b/examples/xml-from-json-conversion/xml_from_json_conversion.bal
@@ -1,5 +1,5 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
 
 public function main() returns error? {
     // Creates a JSON value.
@@ -12,8 +12,7 @@ public function main() returns error? {
             },
             "codes": ["4", "8"]
         }};
-    // Converts the JSON value to XML using a default `attributePrefix` (i.e., the `@` character)
-    // and the default `arrayEntryTag` (i.e., `root`).
-    xml? xmlValue = check xmldata:fromJson(jsonValue);
+    // Converts the JSON value to XML using a default `attributePrefix` (i.e., the `@` character).
+    xml xmlValue = check xmldata:fromJson(jsonValue);
     io:println(xmlValue);
 }

--- a/examples/xml-from-json-conversion/xml_from_json_conversion.md
+++ b/examples/xml-from-json-conversion/xml_from_json_conversion.md
@@ -1,8 +1,8 @@
 # JSON to XML conversion
 
-The `xmldata` library provides an API to perform conversions from JSON to XML.
+The `data.xmldata` library provides an API to perform conversions from JSON to XML.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_from_json_conversion.bal :::
 

--- a/examples/xml-from-json-conversion/xml_from_json_conversion.out
+++ b/examples/xml-from-json-conversion/xml_from_json_conversion.out
@@ -1,2 +1,2 @@
-$ bal run xml_json_conversion.bal
+$ bal run xml_from_json_conversion.bal
 <Store id="AST"><name>Anne</name><address><street>Main</street><city>94</city></address><codes>4</codes><codes>8</codes></Store>

--- a/examples/xml-from-record-conversion/xml_from_record_conversion.bal
+++ b/examples/xml-from-record-conversion/xml_from_record_conversion.bal
@@ -1,5 +1,5 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
 
 // Defines a record type with annotations.
 @xmldata:Namespace {

--- a/examples/xml-from-record-conversion/xml_from_record_conversion.md
+++ b/examples/xml-from-record-conversion/xml_from_record_conversion.md
@@ -1,8 +1,8 @@
 # Record to XML conversion
 
-The `xmldata` library provides APIs to perform the conversion from `Ballerina record/map<anydata>` to XML.
+The `data.xmldata` library provides APIs to perform the conversion from a Ballerina record to XML.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_from_record_conversion.bal :::
 

--- a/examples/xml-to-json-conversion/xml_to_json_conversion.bal
+++ b/examples/xml-to-json-conversion/xml_to_json_conversion.bal
@@ -1,5 +1,19 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
+
+// Defines a record type to represent the XML structure.
+type Address record {
+    string street;
+    string city;
+};
+
+type Store record {
+    string name;
+    Address address;
+    string[] codes;
+    @xmldata:Attribute
+    string id;
+};
 
 public function main() returns error? {
     // Creates an XML value.
@@ -12,8 +26,9 @@ public function main() returns error? {
                           <codes>4</codes>
                           <codes>8</codes>
                         </Store>`;
-    // Converts the XML to JSON value using a default `attributePrefix` (i.e., the `@` character)
-    // and the default `preserveNamespaces` (i.e., `true`).
-    json jsonValue = check xmldata:toJson(xmlValue);
+    // Converts the XML value to a record type.
+    Store store = check xmldata:parseAsType(xmlValue);
+    // Converts the record value to a JSON value.
+    json jsonValue = store.toJson();
     io:println(jsonValue);
 }

--- a/examples/xml-to-json-conversion/xml_to_json_conversion.md
+++ b/examples/xml-to-json-conversion/xml_to_json_conversion.md
@@ -1,8 +1,8 @@
 # XML to JSON conversion
 
-The `xmldata` library provides an API to perform conversions from XML to JSON.
+The `data.xmldata` library provides APIs to convert XML to a Ballerina record, which can then be converted to JSON.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_to_json_conversion.bal :::
 

--- a/examples/xml-to-json-conversion/xml_to_json_conversion.out
+++ b/examples/xml-to-json-conversion/xml_to_json_conversion.out
@@ -1,2 +1,2 @@
-$ bal run xml_json_conversion.bal
-{"Store":{"name":"Anne","address":{"street":"Main","city":"94"},"codes":["4","8"],"@id":"AST"}}
+$ bal run xml_to_json_conversion.bal
+{"name":"Anne","address":{"street":"Main","city":"94"},"codes":["4","8"],"id":"AST"}

--- a/examples/xml-to-record-conversion/xml_to_record_conversion.bal
+++ b/examples/xml-to-record-conversion/xml_to_record_conversion.bal
@@ -1,5 +1,5 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
 
 // Defines a record type with annotations.
 @xmldata:Namespace {
@@ -10,13 +10,11 @@ type Invoice record {
     int id;
     Item[] purchased_item;
     @xmldata:Attribute
-    string 'xmlns?;
-    @xmldata:Attribute
     string status?;
 };
 
 @xmldata:Namespace {
-    uri: "http://example2.com"
+    uri: "example.com"
 }
 type Item record {
     string itemCode;
@@ -38,6 +36,6 @@ public function main() returns error? {
                     </ns:Invoice>`;
 
     // Converts an XML representation to its `record` representation.
-    Invoice output = check xmldata:fromXml(data);
+    Invoice output = check xmldata:parseAsType(data);
     io:println(output);
 }

--- a/examples/xml-to-record-conversion/xml_to_record_conversion.md
+++ b/examples/xml-to-record-conversion/xml_to_record_conversion.md
@@ -1,8 +1,8 @@
 # XML to Record conversion
 
-The `xmldata` library provides an API to perform the conversion from XML to `Ballerina record/map<anydata>`.
+The `data.xmldata` library provides an API to perform the conversion from XML to a Ballerina record.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_to_record_conversion.bal :::
 

--- a/examples/xml-to-record-conversion/xml_to_record_conversion.out
+++ b/examples/xml-to-record-conversion/xml_to_record_conversion.out
@@ -1,2 +1,2 @@
 $ bal run xml_to_record_conversion.bal
-{"id":1,"purchased_item":[{"itemCode":"223345","item_count":1},{"itemCode":"223300","item_count":7}],"xmlns":"example.com","status":"paid"}
+{"id":1,"purchased_item":[{"itemCode":"223345","item_count":1},{"itemCode":"223300","item_count":7}],"status":"paid"}


### PR DESCRIPTION
## Purpose
$subject please

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary

This PR updates XML data handling examples to migrate from the deprecated `ballerina/xmldata` package to the `ballerina/data.xmldata` package, ensuring continued compatibility with the platform's standard library.

## Changes

The PR modifies four example modules demonstrating XML data conversion:

- **xml-from-json-conversion**: Updated to import `ballerina/data.xmldata` and adjusted the return type from nullable to non-nullable `xml`.

- **xml-from-record-conversion**: Updated to import `ballerina/data.xmldata` while maintaining existing XML data annotations and conversion logic.

- **xml-to-json-conversion**: Updated to import `ballerina/data.xmldata` and refactored the conversion approach to define typed Ballerina records that model the XML structure, then convert the parsed record to JSON using the record's native JSON serialization.

- **xml-to-record-conversion**: Updated to import `ballerina/data.xmldata`, changed the conversion function from `xmldata:fromXml()` to `xmldata:parseAsType()`, and adjusted XML namespace configuration for improved consistency.

All examples also include updated documentation references pointing to the new `data.xmldata` module instead of the deprecated `xmldata` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->