### PR TITLE
Use data.xmldata package for deprecated xmldata package

### DIFF
--- a/examples/xml-from-json-conversion/xml_from_json_conversion.bal
+++ b/examples/xml-from-json-conversion/xml_from_json_conversion.bal
@@ -1,5 +1,5 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
 
 public function main() returns error? {
     // Creates a JSON value.
@@ -12,8 +12,7 @@ public function main() returns error? {
             },
             "codes": ["4", "8"]
         }};
-    // Converts the JSON value to XML using a default `attributePrefix` (i.e., the `@` character)
-    // and the default `arrayEntryTag` (i.e., `root`).
-    xml? xmlValue = check xmldata:fromJson(jsonValue);
+    // Converts the JSON value to XML using a default `attributePrefix` (i.e., the `@` character).
+    xml xmlValue = check xmldata:fromJson(jsonValue);
     io:println(xmlValue);
 }

--- a/examples/xml-from-json-conversion/xml_from_json_conversion.md
+++ b/examples/xml-from-json-conversion/xml_from_json_conversion.md
@@ -1,8 +1,8 @@
 # JSON to XML conversion
 
-The `xmldata` library provides an API to perform conversions from JSON to XML.
+The `data.xmldata` library provides an API to perform conversions from JSON to XML.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_from_json_conversion.bal :::
 

--- a/examples/xml-from-json-conversion/xml_from_json_conversion.out
+++ b/examples/xml-from-json-conversion/xml_from_json_conversion.out
@@ -1,2 +1,2 @@
-$ bal run xml_json_conversion.bal
+$ bal run xml_from_json_conversion.bal
 <Store id="AST"><name>Anne</name><address><street>Main</street><city>94</city></address><codes>4</codes><codes>8</codes></Store>

--- a/examples/xml-from-record-conversion/xml_from_record_conversion.bal
+++ b/examples/xml-from-record-conversion/xml_from_record_conversion.bal
@@ -1,5 +1,5 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
 
 // Defines a record type with annotations.
 @xmldata:Namespace {

--- a/examples/xml-from-record-conversion/xml_from_record_conversion.md
+++ b/examples/xml-from-record-conversion/xml_from_record_conversion.md
@@ -1,8 +1,8 @@
 # Record to XML conversion
 
-The `xmldata` library provides APIs to perform the conversion from `Ballerina record/map<anydata>` to XML.
+The `data.xmldata` library provides APIs to perform the conversion from a Ballerina record to XML.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_from_record_conversion.bal :::
 

--- a/examples/xml-to-json-conversion/xml_to_json_conversion.bal
+++ b/examples/xml-to-json-conversion/xml_to_json_conversion.bal
@@ -1,5 +1,19 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
+
+// Defines a record type to represent the XML structure.
+type Address record {
+    string street;
+    string city;
+};
+
+type Store record {
+    string name;
+    Address address;
+    string[] codes;
+    @xmldata:Attribute
+    string id;
+};
 
 public function main() returns error? {
     // Creates an XML value.
@@ -12,8 +26,9 @@ public function main() returns error? {
                           <codes>4</codes>
                           <codes>8</codes>
                         </Store>`;
-    // Converts the XML to JSON value using a default `attributePrefix` (i.e., the `@` character)
-    // and the default `preserveNamespaces` (i.e., `true`).
-    json jsonValue = check xmldata:toJson(xmlValue);
+    // Converts the XML value to a record type.
+    Store store = check xmldata:parseAsType(xmlValue);
+    // Converts the record value to a JSON value.
+    json jsonValue = store.toJson();
     io:println(jsonValue);
 }

--- a/examples/xml-to-json-conversion/xml_to_json_conversion.md
+++ b/examples/xml-to-json-conversion/xml_to_json_conversion.md
@@ -1,8 +1,8 @@
 # XML to JSON conversion
 
-The `xmldata` library provides an API to perform conversions from XML to JSON.
+The `data.xmldata` library provides APIs to convert XML to a Ballerina record, which can then be converted to JSON.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_to_json_conversion.bal :::
 

--- a/examples/xml-to-json-conversion/xml_to_json_conversion.out
+++ b/examples/xml-to-json-conversion/xml_to_json_conversion.out
@@ -1,2 +1,2 @@
-$ bal run xml_json_conversion.bal
-{"Store":{"name":"Anne","address":{"street":"Main","city":"94"},"codes":["4","8"],"@id":"AST"}}
+$ bal run xml_to_json_conversion.bal
+{"name":"Anne","address":{"street":"Main","city":"94"},"codes":["4","8"],"id":"AST"}

--- a/examples/xml-to-record-conversion/xml_to_record_conversion.bal
+++ b/examples/xml-to-record-conversion/xml_to_record_conversion.bal
@@ -1,5 +1,5 @@
+import ballerina/data.xmldata;
 import ballerina/io;
-import ballerina/xmldata;
 
 // Defines a record type with annotations.
 @xmldata:Namespace {
@@ -10,13 +10,11 @@ type Invoice record {
     int id;
     Item[] purchased_item;
     @xmldata:Attribute
-    string 'xmlns?;
-    @xmldata:Attribute
     string status?;
 };
 
 @xmldata:Namespace {
-    uri: "http://example2.com"
+    uri: "example.com"
 }
 type Item record {
     string itemCode;
@@ -38,6 +36,6 @@ public function main() returns error? {
                     </ns:Invoice>`;
 
     // Converts an XML representation to its `record` representation.
-    Invoice output = check xmldata:fromXml(data);
+    Invoice output = check xmldata:parseAsType(data);
     io:println(output);
 }

--- a/examples/xml-to-record-conversion/xml_to_record_conversion.md
+++ b/examples/xml-to-record-conversion/xml_to_record_conversion.md
@@ -1,8 +1,8 @@
 # XML to Record conversion
 
-The `xmldata` library provides an API to perform the conversion from XML to `Ballerina record/map<anydata>`.
+The `data.xmldata` library provides an API to perform the conversion from XML to a Ballerina record.
 
-For more information on the underlying module, see the [`xmldata` module](https://lib.ballerina.io/ballerina/xmldata/latest/).
+For more information on the underlying module, see the [`data.xmldata` module](https://lib.ballerina.io/ballerina/data.xmldata/latest/).
 
 ::: code xml_to_record_conversion.bal :::
 

--- a/examples/xml-to-record-conversion/xml_to_record_conversion.out
+++ b/examples/xml-to-record-conversion/xml_to_record_conversion.out
@@ -1,2 +1,2 @@
 $ bal run xml_to_record_conversion.bal
-{"id":1,"purchased_item":[{"itemCode":"223345","item_count":1},{"itemCode":"223300","item_count":7}],"xmlns":"example.com","status":"paid"}
+{"id":1,"purchased_item":[{"itemCode":"223345","item_count":1},{"itemCode":"223300","item_count":7}],"status":"paid"}


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2-enterprise/integration-engineering/issues/747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request migrates the example code and documentation from the deprecated `ballerina/xmldata` package to the new `ballerina/data.xmldata` package across multiple XML conversion examples.

## Changes

**Updated Files:**
- `examples/xml-from-json-conversion/` - Updated import and adjusted variable type from nullable to non-nullable XML
- `examples/xml-from-record-conversion/` - Updated import to use the new package
- `examples/xml-to-json-conversion/` - Refactored conversion approach to use structured record mapping instead of direct XML-to-JSON conversion
- `examples/xml-to-record-conversion/` - Updated import, adjusted data-binding annotations and namespace configuration, and replaced the conversion method call

**Documentation Updates:**
All corresponding markdown documentation files have been updated to reference the `data.xmldata` module and adjusted external documentation links accordingly.

## Impact

- Aligns examples with the current supported XML data handling package
- Updates API method calls where needed (e.g., `fromXml` to `parseAsType` in XML-to-record conversion)
- Improves consistency across example code by using standardized approach for XML operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->