### PR TITLE
chore: port changes from 13.x branch

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       isPreRelease:
-        description: 'Tag created is a pre-release tag'
+        description: "Tag created is a pre-release tag"
         required: true
-        default: 'false'
+        default: "false"
       preReleaseSuffix:
-        description: 'The text that will be suffixed to the Git tag. e.g., rc1'
+        description: "The text that will be suffixed to the Git tag. e.g., rc1"
         required: false
-        default: ''
+        default: ""
 
 permissions:
   id-token: write
@@ -26,8 +26,8 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '21.0.3'
+          distribution: "temurin"
+          java-version: "21.0.3"
       - name: Set version env variable
         id: version-set
         run: |
@@ -77,8 +77,8 @@ jobs:
           githubAccessToken: ${{ secrets.GITHUB_TOKEN }}
           ballerinaBotWorkflow: $ {{ secrets.BALLERINA_BOT_WORKFLOW }}
         run: |
-          ./gradlew build -x project-api-tests:test -Pversion=${VERSION} -x test
-          ./gradlew release -Prelease.useAutomaticVersion=true -x test
+          ./gradlew build -x project-api-tests:test -Pversion=${VERSION}
+          ./gradlew release -x project-api-tests:test -Prelease.useAutomaticVersion=true
       - name: Checkout docker repo
         uses: actions/checkout@v3
         with:
@@ -108,17 +108,17 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'ballerina/ballerina:release-test'
-          skip-dirs: 'ballerina/runtime/examples'
-          format: 'table'
-          exit-code: '1'
+          image-ref: "ballerina/ballerina:release-test"
+          skip-dirs: "ballerina/runtime/examples"
+          format: "table"
+          exit-code: "1"
           timeout: "10m0s"
       - name: cosign-installer
         uses: sigstore/cosign-installer@v3.5.0
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
       - name: Install GitHub CLI
         run: |
           npm install -g github-cli
@@ -562,8 +562,8 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
-          java-version: '21.0.3'
+          distribution: "temurin"
+          java-version: "21.0.3"
       - name: Download MacOS Intaller Zip
         run: |
           wget https://github.com/ballerina-platform/ballerina-distribution/releases/download/v${{ needs.publish-release.outputs.release-version }}/ballerina-${{ needs.publish-release.outputs.project-version }}-macos.zip
@@ -699,11 +699,11 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
-          java-version: '21.0.3'
+          distribution: "temurin"
+          java-version: "21.0.3"
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '2.1.x'
+          dotnet-version: "2.1.x"
       - name: Install GUID Generator
         run: dotnet tool install -g dotnet-guid --version 0.5.2
       - name: Set up Wix toolkit

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -1213,9 +1213,12 @@ def buildAndTestStandardLibs = { distPath, stdlibTest, isStageTest, testMinorVer
     println "Testing standard library ${stdlibTest}"
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         if (!isStageTest) {
-            exec {
-                workingDir "${distPath}/${stdlibTest}"
-                commandLine 'cmd', '/c', "${distPath}/bin/bal.bat init test"
+            def tomlFile = new File("${distPath}/${stdlibTest}/Ballerina.toml")
+            if (!tomlFile.exists()) {
+                exec {
+                    workingDir "${distPath}/${stdlibTest}"
+                    commandLine 'cmd', '/c', "${distPath}/bin/bal.bat init test"
+                }
             }
             if (stdlibTest == 'transaction') {
                 addH2Dependency("${distPath}/${stdlibTest}/Ballerina.toml")
@@ -1239,9 +1242,12 @@ def buildAndTestStandardLibs = { distPath, stdlibTest, isStageTest, testMinorVer
         }
     } else {
         if (!isStageTest) {
-            exec {
-                workingDir "${distPath}/${stdlibTest}"
-                commandLine 'sh', '-c', "${distPath}/bin/bal init test"
+            def tomlFile = new File("${distPath}/${stdlibTest}/Ballerina.toml")
+            if (!tomlFile.exists()) {
+                exec {
+                    workingDir "${distPath}/${stdlibTest}"
+                    commandLine 'sh', '-c', "${distPath}/bin/bal init test"
+                }
             }
             if (stdlibTest == 'transaction') {
                 addH2Dependency("${distPath}/${stdlibTest}/Ballerina.toml")

--- a/stdlib-integration-tests/index.json
+++ b/stdlib-integration-tests/index.json
@@ -68,5 +68,10 @@
     "name": "Transaction standard library",
     "path": "transaction",
     "enableTest": true
+  },
+  {
+    "name": "Library package test",
+    "path": "library_package_test",
+    "enableTest": true
   }
 ]

--- a/stdlib-integration-tests/library_package_test/Ballerina.toml
+++ b/stdlib-integration-tests/library_package_test/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "test_package"
+version = "0.1.0"
+
+[build-options]
+offline = true
+

--- a/stdlib-integration-tests/library_package_test/main.bal
+++ b/stdlib-integration-tests/library_package_test/main.bal
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io as _;
+import ballerina/jballerina.java.arrays as _;
+import ballerina/math.vector as _;
+import ballerina/persist as _;
+import ballerina/time as _;
+import ballerina/url as _;
+import ballerina/avro as _;
+import ballerina/constraint as _;
+import ballerina/crypto as  _;
+import ballerina/log as  _;
+import ballerina/os as _;
+import ballerina/protobuf as _;
+import ballerina/random as  _;
+import ballerina/xslt as  _;
+import ballerina/data.yaml as _;
+import ballerina/file as _;
+import ballerina/ldap as _;
+import ballerina/mime as _;
+import ballerina/tcp as _;
+import ballerina/udp as _;
+import ballerina/uuid as _;
+import ballerina/data.csv as _;
+import ballerina/data.jsondata as _;
+import ballerina/data.xmldata as _;
+import ballerina/edi as _;
+import ballerina/mqtt as _;
+import ballerina/task as _;
+import ballerina/toml as _;
+import ballerina/yaml as _;
+import ballerina/cache as _;
+import ballerina/email as _;
+import ballerina/ftp as _;
+import ballerina/messaging as _;
+import ballerina/auth as _;
+import ballerina/jwt as _;
+import ballerina/oauth2 as _;
+import ballerina/http as _;
+import ballerina/ai as _;
+import ballerina/grpc as _;
+import ballerina/soap as _;
+import ballerina/websocket as _;
+import ballerina/websub as _;
+import ballerina/websubhub as _;
+import ballerina/ai.np as _;
+import ballerina/graphql as _;
+import ballerina/sql as _;
+import ballerina/openapi as _;
+import ballerina/mcp as _;


### PR DESCRIPTION
## Purpose

$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request ports changes from the 13.x branch to master to re-enable tests in the release pipeline and add a new integration test package that validates standard library compilation.

## Changes

- Release build workflow
  - Updated .github/workflows/publish-release.yml to run Gradle build/release tasks with explicit version/release properties (-Pversion, -Prelease.useAutomaticVersion=true) and removed the global test exclusion flag; the workflow still excludes only the project-api-tests:test task. Various workflow string literals were normalized to use double quotes.

- Build script
  - Modified ballerina/build.gradle so the standard-library test package initialization step (bal init test / bal.bat init test) runs only when the package manifest (Ballerina.toml) is missing, avoiding redundant initialization.

- Test infrastructure
  - Added a new library package integration test at stdlib-integration-tests/library_package_test (includes Ballerina.toml and main.bal that imports numerous stdlib modules).
  - Registered the new test in stdlib-integration-tests/index.json to enable it in the integration test suite.

These updates ensure library compilation tests are executed as part of the release process while avoiding unnecessary package initialization during standard library builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->