### PR TITLE
Update ballerina/ftp to 2.19.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ stdlibYamlVersion=0.8.0
 # Stdlib Level 05
 stdlibCacheVersion=3.10.0
 stdlibEmailVersion=2.13.0
-stdlibFtpVersion=2.18.0
+stdlibFtpVersion=2.19.0
 stdlibMessagingVersion=1.0.0
 
 # Stdlib Level 06


### PR DESCRIPTION
## Purpose
Bump `stdlibFtpVersion` to 2.19.0 in 2201.13.x.

## Approach
Updated `gradle.properties` to consume the newly released `ballerina/ftp` 2.19.0 from Ballerina Central.