### PR TITLE
Bump the crypto version for 2201.13.x release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ observeVersion=1.7.1
 # Stdlib Level 02
 stdlibAvroVersion=1.2.1
 stdlibConstraintVersion=1.7.0
-stdlibCryptoVersion=2.10.1
+stdlibCryptoVersion=2.11.0
 stdlibLogVersion=2.17.0
 stdlibOsVersion=1.10.1
 stdlibProtobufVersion=1.8.0


### PR DESCRIPTION
## Purpose

Bump `stdlibCryptoVersion` from 2.10.1 to 2.11.0 on the 2201.13.x branch.

## Notable change in 2.11.0

- Introduce `equalConstantTime` API for timing-safe comparison of byte arrays and strings.
  - Tracking issue: ballerina-platform/ballerina-library#8733

## Approach

Single-line change in `gradle.properties`.

## Automation tests

- Module-level tests live in `module-ballerina-crypto` and ran on the 2.11.0 release.
- Distribution build will exercise the new pin via the standard CI checks on this PR.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: n/a (version-bump only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Related releases

- module-ballerina-crypto v2.11.0