### PR TITLE
Bump the sql version for 2201.13.x release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -77,7 +77,7 @@ stdlibWebsubhubVersion=1.16.0
 # Stdlib Level 09
 stdlibAiNpVersion=0.5.1
 stdlibGraphqlVersion=1.17.0
-stdlibSqlVersion=1.17.1
+stdlibSqlVersion=1.19.0
 
 # OpenAPI Module
 openapiModuleVersion=2.4.1


### PR DESCRIPTION
## Purpose

Bump `stdlibSqlVersion` from 1.17.1 to 1.19.0 on the 2201.13.x branch.

## Notable changes

### 1.19.0
- Add observability metrics for SQL connection pools.
  - Tracking issue: ballerina-platform/ballerina-library#7763

### 1.18.0
- Add support for calling database functions using the `call` method (ballerina-platform/ballerina-library#8635).
- Fix CLOB retrieval as an out parameter in OracleDB stored procedure calls (ballerina-platform/ballerina-library#8386).

## Approach

Single-line change in \`gradle.properties\`.

## Automation tests

- Module-level tests live in \`module-ballerina-sql\` and ran on the 1.18.0 / 1.19.0 releases.
- Distribution build will exercise the new pin via the standard CI checks on this PR.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: n/a (version-bump only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Related releases

- module-ballerina-sql v1.19.0
- module-ballerina-sql v1.18.0