### PR TITLE
Bump stdlib versions for 2201.13.x release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ observeVersion=1.7.1
 # Stdlib Level 02
 stdlibAvroVersion=1.2.1
 stdlibConstraintVersion=1.7.0
-stdlibCryptoVersion=2.10.1
+stdlibCryptoVersion=2.11.0
 stdlibLogVersion=2.17.0
 stdlibOsVersion=1.10.1
 stdlibProtobufVersion=1.8.0
@@ -77,7 +77,7 @@ stdlibWebsubhubVersion=1.16.0
 # Stdlib Level 09
 stdlibAiNpVersion=0.5.1
 stdlibGraphqlVersion=1.17.0
-stdlibSqlVersion=1.17.1
+stdlibSqlVersion=1.19.0
 
 # OpenAPI Module
 openapiModuleVersion=2.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ observeVersion=1.7.1
 # Stdlib Level 02
 stdlibAvroVersion=1.2.1
 stdlibConstraintVersion=1.7.0
-stdlibCryptoVersion=2.11.0
+stdlibCryptoVersion=2.12.0
 stdlibLogVersion=2.17.0
 stdlibOsVersion=1.10.1
 stdlibProtobufVersion=1.8.0


### PR DESCRIPTION
## Purpose

Bump the following stdlib versions on the 2201.13.x branch to match the latest releases on Ballerina Central:

| Property | From | To |
|---|---|---|
| `stdlibCryptoVersion` | 2.10.1 | 2.11.0 |
| `stdlibSqlVersion` | 1.17.1 | 1.19.0 |

`stdlibTcpVersion` (1.13.4 → 1.13.5) was already merged separately in #6367 and is therefore not part of this PR.

## Notable changes

### crypto 2.11.0
- Introduce `equalConstantTime` API for timing-safe comparison of byte arrays and strings (ballerina-platform/ballerina-library#8733).

### sql 1.19.0
- Add observability metrics for SQL connection pools (ballerina-platform/ballerina-library#7763).

### sql 1.18.0 (rolled in via 1.19.0)
- Add support for calling database functions using the `call` method (ballerina-platform/ballerina-library#8635).
- Fix CLOB retrieval as an out parameter in OracleDB stored procedure calls (ballerina-platform/ballerina-library#8386).

## Approach

Two-line change in `gradle.properties`.

## Automation tests

- Module-level tests live in `module-ballerina-crypto` and `module-ballerina-sql` and ran on the corresponding releases.
- Distribution build will exercise the new pins via the standard CI checks on this PR.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: n/a (version-bump only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Related releases

- module-ballerina-crypto v2.11.0
- module-ballerina-sql v1.18.0
- module-ballerina-sql v1.19.0

## Supersedes

- Closes #6368
- Closes #6369