### PR TITLE
Add CVE-2026-5588 and GHSA-w5hq-g745-h8pq to .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,8 @@
 # False positive
 CVE-2020-7768
 CVE-2025-48985
+GHSA-w5hq-g745-h8pq
 
 # Need to be fixed
 CVE-2025-48924
+CVE-2026-5588


### PR DESCRIPTION
## Summary

- **CVE-2026-5588** (`org.bouncycastle:bcpkix-jdk18on` / `bcprov-jdk18on` 1.80): Added to `# Need to be fixed` section — a proper dependency upgrade to 1.84 will be done in a follow-up.
- **GHSA-w5hq-g745-h8pq** (`uuid`): False positive — Trivy is misidentifying the Ballerina `uuid` stdlib bala package as the npm `uuid` package. Added to `# False positive` section.

## Test plan

- [ ] Re-run the `2201.13.x Publish release` workflow and confirm the Trivy step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)