### PR TITLE
Free disk space before Trivy scan to prevent Java DB download failure

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,6 +105,11 @@ jobs:
           tags: ballerina/ballerina:release-test
           build-args: |
             BALLERINA_DIST=ballerina-${{ steps.version-set.outputs.sversion }}.zip
+      - name: Free disk space before Trivy scan
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af --filter "label!=ballerina/ballerina:release-test" || true
+          df -h
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
## Problem

The Trivy scan was failing with:

```
no space left on device
```

when trying to download the Trivy Java DB to `/tmp`. The GitHub Actions runner runs out of disk space after the Gradle build + Docker image build, leaving insufficient room for the ~42 MB Java DB download.

## Fix

Added a **"Free disk space before Trivy scan"** step between the Docker image build and the Trivy scan that:
1. Removes pre-installed tools not needed at this point (`dotnet`, Android SDK, GHC, CodeQL) — typically frees ~15–20 GB
2. Prunes dangling Docker images (keeping `ballerina/ballerina:release-test` which Trivy needs)
3. Prints `df -h` so disk usage is visible in the logs

## Test plan

- [ ] Re-run the `2201.13.x Publish release` workflow and confirm the Trivy Java DB downloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds a disk space optimization step to the publish-release workflow to improve workflow reliability. The new step runs immediately after building the Docker image and before the Trivy vulnerability scan.

The step performs the following actions:
- Removes large pre-installed tools and SDKs (dotnet, Android SDK, GHC, CodeQL) that are not needed for subsequent steps, typically freeing 15–20 GB of disk space
- Prunes unused Docker images while preserving the release-test image needed for the vulnerability scan
- Displays disk usage metrics to verify available space

This change addresses a workflow failure where insufficient disk space prevented the Trivy vulnerability scanner database from downloading to the temporary directory. By freeing disk resources before the scan, the workflow can proceed without interruption.

**Changes Made:**
- `.github/workflows/publish-release.yml`: Added 5 lines for the disk space cleanup step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->