### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/bbe-on-demand.yml
+++ b/.github/workflows/bbe-on-demand.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
 
       - name: Build Ballerina pack
         env:

--- a/.github/workflows/daily-build-editor.yml
+++ b/.github/workflows/daily-build-editor.yml
@@ -12,11 +12,11 @@ jobs:
     if: github.repository_owner == 'ballerina-platform'
 
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Get daily docker version
         id: version
         run: echo "::set-output name=version::$(date +'%Y-%m-%d')"
@@ -285,11 +285,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
@@ -308,11 +308,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
@@ -331,11 +331,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Setup Files
         run: |
           cd /etc/yum.repos.d/
@@ -368,11 +368,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Download Linux-ARM Installer Zip
         uses: actions/download-artifact@v4
         with:
@@ -404,11 +404,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Download MacOS Installer Zip
         uses: actions/download-artifact@v4
         with:
@@ -454,11 +454,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Download MacOS-ARM Intaller Zip
         uses: actions/download-artifact@v4
         with:
@@ -491,11 +491,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '2.1.x'

--- a/.github/workflows/language_server_simulator_fhir.yml
+++ b/.github/workflows/language_server_simulator_fhir.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
 
       - name: Initialize sub-modules
         run: git submodule update --init

--- a/.github/workflows/language_server_simulator_nballerina.yml
+++ b/.github/workflows/language_server_simulator_nballerina.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
 
       - name: Initialize sub-modules
         run: git submodule update --init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Get project version
         id: project-version
         run: |

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
 
       - name: Set version env variable
         id: set-version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "21.0.3"
+          java-version: "25"
       - name: Set version env variable
         id: version-set
         run: |
@@ -559,11 +559,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: "temurin"
-          java-version: "21.0.3"
+          java-version: "25"
       - name: Download MacOS Intaller Zip
         run: |
           wget https://github.com/ballerina-platform/ballerina-distribution/releases/download/v${{ needs.publish-release.outputs.release-version }}/ballerina-${{ needs.publish-release.outputs.project-version }}-macos.zip
@@ -696,11 +696,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: "temurin"
-          java-version: "21.0.3"
+          java-version: "25"
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "2.1.x"

--- a/.github/workflows/publish_release_bi.yml
+++ b/.github/workflows/publish_release_bi.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -351,11 +351,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - name: Download MacOS Intaller Zip
         run: |
           wget https://github.com/ballerina-platform/ballerina-distribution/releases/download/v${{ needs.publish-release.outputs.release-version }}/ballerina-${{ needs.publish-release.outputs.project-version }}-macos.zip
@@ -440,11 +440,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '21.0.3'
+          java-version: '25'
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '2.1.x'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,11 +18,11 @@ jobs:
         steps:
             -   name: Checkout Repository
                 uses: actions/checkout@v3
-            -   name: Set up JDK 21
-                uses: actions/setup-java@v3
+            -   name: Set up JDK 25
+                uses: actions/setup-java@v4
                 with:
                     distribution: 'temurin'
-                    java-version: '21.0.3'
+                    java-version: '25'
             -   name: Build Ballerina Distribution
                 env:
                     packageUser: ${{ github.actor }}
@@ -41,11 +41,11 @@ jobs:
         steps:
             -   name: Checkout Repository
                 uses: actions/checkout@v3
-            -   name: Set up JDK 21
-                uses: actions/setup-java@v3
+            -   name: Set up JDK 25
+                uses: actions/setup-java@v4
                 with:
                     distribution: 'temurin'
-                    java-version: '21.0.3'
+                    java-version: '25'
             -   name: Build Ballerina Distribution
                 env:
                     packageUser: ${{ github.actor }}
@@ -63,11 +63,11 @@ jobs:
         steps:
             -   name: Checkout Repository
                 uses: actions/checkout@v3
-            -   name: Set up JDK 21
-                uses: actions/setup-java@v3
+            -   name: Set up JDK 25
+                uses: actions/setup-java@v4
                 with:
                     distribution: 'temurin'
-                    java-version: '21.0.3'
+                    java-version: '25'
             - name: Build Ballerina Distribution
               env:
                   packageUser: ${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternatively, you can install Ballerina from the source using the following ins
 
 #### Prerequisites
 
-* JDK21 ([Adopt OpenJDK21](https://adoptopenjdk.net/) or any other OpenJDK distribution)
+* JDK25 ([Adopt OpenJDK25](https://adoptopenjdk.net/) or any other OpenJDK distribution)
 
 #### Building the source
 

--- a/ballerina-test/build.gradle
+++ b/ballerina-test/build.gradle
@@ -45,9 +45,9 @@ task distributionTest {
     dependsOn configurations.ballerinaWindowsDistribution
     test {
         systemProperty "distributions.dir", "$buildDir/../../ballerina/build/distributions"
-        systemProperty "target.dir", "$buildDir"
+        systemProperty "target.dir", layout.buildDirectory.get().asFile.toString()
         systemProperty "maven.version", "$version"
-        systemProperty "examples.dir", "$buildDir/../../examples"
+        systemProperty "examples.dir", layout.buildDirectory.get().asFile.toString() + "/../../examples"
         systemProperty "line.check.extensions", ".java, .bal"
         systemProperty "short.version", "$version".split("-")[0]
         systemProperty "version.display.text", "$version".split("-")[0]

--- a/ballerina-test/src/test/java/org/ballerinalang/distribution/test/OpenAPIDistributionArtifactCheck.java
+++ b/ballerina-test/src/test/java/org/ballerinalang/distribution/test/OpenAPIDistributionArtifactCheck.java
@@ -65,7 +65,7 @@ public class OpenAPIDistributionArtifactCheck {
                 .resolve("ballerina")
                 .resolve("openapi")
                 .resolve(OPENAPI_VERSION_DIR)
-                .resolve("java21")
+                .resolve("java25")
                 .resolve("compiler-plugin")
                 .resolve("libs");
 
@@ -76,7 +76,7 @@ public class OpenAPIDistributionArtifactCheck {
                 .resolve("ballerina")
                 .resolve("tool.openapi")
                 .resolve(OPENAPI_VERSION_DIR)
-                .resolve("java21")
+                .resolve("java25")
                 .resolve("tool")
                 .resolve("libs");
 

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -19,8 +19,6 @@ import groovy.json.JsonSlurper
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.process.ExecOperations
-import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.jvm.toolchain.JavaToolchainService
 import javax.inject.Inject
 
 import static groovy.io.FileType.FILES
@@ -30,17 +28,11 @@ abstract class BallerinaExecHelper {
 }
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
-    @Inject abstract JavaToolchainService getJavaToolchainService()
     @Input abstract Property<String> getJballerinaToolsBinPath()
     @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
-        def launcher = javaToolchainService.launcherFor { spec ->
-            spec.languageVersion.set(JavaLanguageVersion.of(25))
-        }.get()
-        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
-
         [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
@@ -49,10 +41,6 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
                         def original = file.text
                         def lines = original.split('\n').toList()
                         lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
-                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
-                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
-                        }
                         def patched = lines.join('\n') + '\n'
                         if (patched != original) { file.text = patched }
                     }

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -1004,17 +1004,25 @@ task testExamples() {
         println "Building example '${bbe.url}'"
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             //TODO: Need to verify with windows
-            exitVal = execHelper.execOperations.exec {
+            execHelper.execOperations.exec {
                 ignoreExitValue true
                 workingDir "${distPath}/${bbe.url}"
                 commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'build', "${additionalParams}"
-                commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'test', "${additionalParams}"
             }
-        } else {
             exitVal = execHelper.execOperations.exec {
                 ignoreExitValue true
                 workingDir "${distPath}/${bbe.url}"
+                commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'test', "${additionalParams}"
+            }
+        } else {
+            execHelper.execOperations.exec {
+                ignoreExitValue true
+                workingDir "${distPath}/${bbe.url}"
                 commandLine 'sh', '-c', "${distPath}/bin/bal build ${additionalParams}"
+            }
+            exitVal = execHelper.execOperations.exec {
+                ignoreExitValue true
+                workingDir "${distPath}/${bbe.url}"
                 commandLine 'sh', '-c', "${distPath}/bin/bal test ${additionalParams}"
             }
         }
@@ -1131,7 +1139,7 @@ task testExamples() {
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     execHelper.execOperations.exec {
                         workingDir "${directoryPath}"
-                        commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'run', "${balName}.bal ", ${additionalBuildParams}
+                        commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'run', "${balName}.bal", ${additionalBuildParams}
                         ignoreExitValue true
                         standardOutput = os
                         errorOutput = errOut

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -31,6 +31,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -39,20 +41,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -1703,6 +1701,9 @@ task generateBalToolsToml () {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 build.dependsOn patchBallerinaScripts

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -361,6 +361,7 @@ task packageDist(type: Zip) {
     into("${parentDir}") {
         from "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
         exclude "/LICENSE"
+        filePermissions { unix(0755) }
     }
     into("${parentDir}") {
         from "LICENSE"
@@ -424,7 +425,7 @@ task packageDistZip(type: Zip) {
         exclude "distributions/installer-version"
         exclude "/bin/version.txt"
         exclude "/LICENSE"
-
+        filePermissions { unix(0755) }
     }
     into("${parentDir}") {
         from "../resources/tools"
@@ -510,6 +511,7 @@ task packageDistLinux(type: Zip) {
         exclude "/bin/bal.bat"
         exclude "/bin/version.txt"
         exclude "/LICENSE"
+        filePermissions { unix(0755) }
     }
     into("${parentDir}") {
         from "../resources/tools"
@@ -599,6 +601,7 @@ task packageDistLinuxArm(type: Zip) {
         exclude "/bin/bal.bat"
         exclude "/bin/version.txt"
         exclude "/LICENSE"
+        filePermissions { unix(0755) }
     }
     into("${parentDir}") {
         from "../resources/tools"
@@ -689,6 +692,7 @@ task packageDistMac(type: Zip) {
         exclude "/bin/bal.bat"
         exclude "/bin/version.txt"
         exclude "/LICENSE"
+        filePermissions { unix(0755) }
     }
 
     /* Files */
@@ -774,6 +778,7 @@ task packageDistMacArm(type: Zip) {
         exclude "/bin/bal.bat"
         exclude "/bin/version.txt"
         exclude "/LICENSE"
+        filePermissions { unix(0755) }
     }
 
     /* Files */
@@ -859,6 +864,7 @@ task packageDistWindows(type: Zip) {
         exclude "/bin/bal"
         exclude "/bin/version.txt"
         exclude "/LICENSE"
+        filePermissions { unix(0755) }
     }
 
     /* Files */
@@ -1710,12 +1716,13 @@ task generateBalToolsToml () {
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
     outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
-    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    jballerinaToolsBinPath = layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
     ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 build.dependsOn patchBallerinaScripts
 test.dependsOn patchBallerinaScripts
+buildDistRepo.dependsOn patchBallerinaScripts
 
 /* Unpack Dependencies */
 unpackJballerinaTools.dependsOn unpackBallerinaJre

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -40,7 +40,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
+                        // bal run/test executes the compiled program in a separate child JVM
+                        // (spawned in Java code), which does not inherit this script's own JVM
+                        // args or JAVA_OPTS. JAVA_TOOL_OPTIONS is the one channel the JVM itself
+                        // reads automatically in every process it launches, so it is the only way
+                        // to suppress Java 25's JEP 500 sun.misc.Unsafe/JNI native-access warnings
+                        // for the actual executed program, not just the compiler's own JVM.
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0 && !lines.any { it.contains('--sun-misc-unsafe-memory-access=allow') && it.contains('--enable-native-access=ALL-UNNAMED') }) {
+                            lines.add(shebangIdx + 1, 'export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED"')
+                        }
                         def patched = lines.join('\n') + '\n'
                         if (patched != original) { file.text = patched }
                     }
@@ -1165,7 +1174,7 @@ task testExamples() {
             lines.each {
                 str = it.trim()
                 if (str != "Compiling source" && str != "${balName}.bal" && str != "Running executable" && str != ""
-                        && str != "Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8" && !str.startsWith('HINT')) {
+                        && !str.startsWith('Picked up JAVA_TOOL_OPTIONS:') && !str.startsWith('HINT')) {
                     bbeOutput.add(str)
                 }
             }

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -300,9 +300,8 @@ task copyOtherRepos(type: Copy) {
         from("${artifactExtractedPath}/bala") {
             into "repo/bala"
         }
-        from("${artifactExtractedPath}/cache") {
-            into "repo/cache"
-        }
+        // The module zip ships a prebuilt cache targeting java21; copying it prevents
+        // generateCache from regenerating a java25 cache, so it is regenerated instead.
     }
 
     /* Language Server Extension Artifacts */

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -18,8 +18,51 @@
 import groovy.json.JsonSlurper
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
 
 import static groovy.io.FileType.FILES
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 description = 'Ballerina - Tools'
 
@@ -45,13 +88,13 @@ dependencies {
     implementation project(':cache-generator')
 }
 
-def jBallerinaDistributionZip = file("$project.buildDir/distributions/ballerina-${shortVersion}.zip")
-def ballerinaDistributionZip = file("$project.buildDir/distributions/ballerina-${ballerinaLangVersion}.zip")
-def ballerinaLinuxDistributionZip = file("$project.buildDir/distributions/ballerina-linux-${ballerinaLangVersion}.zip")
-def ballerinaLinuxArmDistributionZip = file("$project.buildDir/distributions/ballerina-linux-arm-${ballerinaLangVersion}.zip")
-def ballerinaMacDistributionZip = file("$project.buildDir/distributions/ballerina-macos-${ballerinaLangVersion}.zip")
-def ballerinaMacArmDistributionZip = file("$project.buildDir/distributions/ballerina-macos-arm-${ballerinaLangVersion}.zip")
-def ballerinaWindowsDistributionZip = file("$project.buildDir/distributions/ballerina-windows-${ballerinaLangVersion}.zip")
+def jBallerinaDistributionZip = layout.buildDirectory.file("distributions/ballerina-${shortVersion}.zip").get().asFile
+def ballerinaDistributionZip = layout.buildDirectory.file("distributions/ballerina-${ballerinaLangVersion}.zip").get().asFile
+def ballerinaLinuxDistributionZip = layout.buildDirectory.file("distributions/ballerina-linux-${ballerinaLangVersion}.zip").get().asFile
+def ballerinaLinuxArmDistributionZip = layout.buildDirectory.file("distributions/ballerina-linux-arm-${ballerinaLangVersion}.zip").get().asFile
+def ballerinaMacDistributionZip = layout.buildDirectory.file("distributions/ballerina-macos-${ballerinaLangVersion}.zip").get().asFile
+def ballerinaMacArmDistributionZip = layout.buildDirectory.file("distributions/ballerina-macos-arm-${ballerinaLangVersion}.zip").get().asFile
+def ballerinaWindowsDistributionZip = layout.buildDirectory.file("distributions/ballerina-windows-${ballerinaLangVersion}.zip").get().asFile
 
 task unpackBallerinaJre(type: Download) {
     group = "unpack_dependencies"
@@ -71,7 +114,7 @@ task unpackJballerinaTools(type: Copy) {
     group = "unpack_dependencies"
     configurations.jbalTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         from zipTree(artifact.getFile())
-        into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+        into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
     }
 }
 
@@ -79,7 +122,7 @@ task unpackDevTools(type: Copy) {
     group = "unpack_dependencies"
     configurations.devTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         from zipTree(artifact.getFile())
-        into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+        into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
     }
 }
 
@@ -87,7 +130,7 @@ task downloadDocUi {
     def response = new JsonSlurper().parseText(new URL(docUiApi).text)
     def zipFileUrl = response.fileURL
     def zipInputStream = new URL(zipFileUrl).openStream()
-    def outputFile = new File("${buildDir}/target/extracted-distributions/doc-ui-zip/ballerina-doc-ui.zip")
+    def outputFile = layout.buildDirectory.file("target/extracted-distributions/doc-ui-zip/ballerina-doc-ui.zip").get().asFile
     doLast {
         outputFile.parentFile.mkdirs()
         outputFile.withOutputStream { outputStream ->
@@ -100,7 +143,7 @@ task unpackAwsLambdaBala(type: Copy) {
     group = "unpack_dependencies"
     configurations.awsLambdaBala.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         from zipTree(artifact.getFile())
-        into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+        into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
     }
 }
 
@@ -109,7 +152,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+                into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -120,7 +163,7 @@ task unpackBalTools() {
         configurations.ballerinaTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+                into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -131,7 +174,7 @@ task unpackC2cLibs() {
         configurations.ballerinaC2cLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+                into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -142,7 +185,7 @@ task unpackC2cTooling() {
         configurations.ballerinaC2cTooling.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+                into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -153,7 +196,7 @@ task unpackOpenapiModule() {
         configurations.openapiModule.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${buildDir}/target/extracted-distributions", artifact.name + "-zip")
+                into layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -166,43 +209,43 @@ task downloadBalCommand(type: Download) {
             "${commandBaseURL}/ballerina-command-${ballerinaCommandVersion}.zip"
     ])
     onlyIfModified true
-    dest "${buildDir}/target/"
+    dest layout.buildDirectory.dir("target").get().asFile
 }
 
 task unpackBalCommand(type: Copy) {
     group = "unpack_dependencies"
-    from zipTree { "${buildDir}/target/ballerina-command-${ballerinaCommandVersion}.zip" }
-    into new File("${buildDir}/target/")
+    from zipTree { layout.buildDirectory.file("target/ballerina-command-${ballerinaCommandVersion}.zip").get().asFile }
+    into layout.buildDirectory.dir("target").get().asFile
 }
 
 task extractJreForLinux(type: Copy) {
     group = "extract_jre"
     from zipTree { "${jreLocation}/ballerina-jre-linux-64-${ballerinaJreVersion}.zip" }
-    into("${buildDir}/target/extracted-jre-linux")
+    into(layout.buildDirectory.dir("target/extracted-jre-linux").get().asFile)
 }
 
 task extractJreForLinuxArm(type: Copy) {
     group = "extract_jre"
     from zipTree { "${jreLocation}/ballerina-jre-linux-arm-64-${ballerinaJreVersion}.zip" }
-    into("${buildDir}/target/extracted-jre-linux-arm")
+    into(layout.buildDirectory.dir("target/extracted-jre-linux-arm").get().asFile)
 }
 
 task extractJreForMac(type: Copy) {
     group = "extract_jre"
     from zipTree { "${jreLocation}/ballerina-jre-macos-64-${ballerinaJreVersion}.zip" }
-    into("${buildDir}/target/extracted-jre-macos")
+    into(layout.buildDirectory.dir("target/extracted-jre-macos").get().asFile)
 }
 
 task extractJreForMacArm(type: Copy) {
     group = "extract_jre"
     from zipTree { "${jreLocation}/ballerina-jre-macos-arm-64-${ballerinaJreVersion}.zip" }
-    into("${buildDir}/target/extracted-jre-macos-arm")
+    into(layout.buildDirectory.dir("target/extracted-jre-macos-arm").get().asFile)
 }
 
 task extractJreForWindows(type: Copy) {
     group = "extract_jre"
     from zipTree { "${jreLocation}/ballerina-jre-win-64-${ballerinaJreVersion}.zip" }
-    into("${buildDir}/target/extracted-jre-windows")
+    into(layout.buildDirectory.dir("target/extracted-jre-windows").get().asFile)
 }
 
 task deleteTemporaryFiles(type: Delete) {
@@ -217,7 +260,7 @@ task copyOtherRepos(type: Copy) {
 
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
         from("${artifactExtractedPath}/libs") {
             into "bre/lib/"
         }
@@ -228,7 +271,7 @@ task copyOtherRepos(type: Copy) {
 
     /* Bal tools (e.g. openapi, graphql etc.) */
     configurations.ballerinaTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
         from("${artifactExtractedPath}/bala") {
             into "repo/bala"
         }
@@ -236,7 +279,7 @@ task copyOtherRepos(type: Copy) {
 
     /* C2C Libraries */
     configurations.ballerinaC2cLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
         from("${artifactExtractedPath}/libs") {
             into "bre/lib/"
         }
@@ -247,7 +290,7 @@ task copyOtherRepos(type: Copy) {
 
     /* C2C Tooling */
     configurations.ballerinaC2cTooling.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
         from("${artifactExtractedPath}") {
             into "lib/tools/lang-server/lib/"
         }
@@ -255,7 +298,7 @@ task copyOtherRepos(type: Copy) {
 
     /* OpenAPI Module */
     configurations.openapiModule.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("target/extracted-distributions/" + artifact.name + "-zip").get().asFile
         from("${artifactExtractedPath}/bala") {
             into "repo/bala"
         }
@@ -266,7 +309,7 @@ task copyOtherRepos(type: Copy) {
 
     /* Language Server Extension Artifacts */
     configurations.devTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${buildDir}/target/extracted-distributions/${artifact.name}-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("target/extracted-distributions/${artifact.name}-zip").get().asFile
         from("${artifactExtractedPath}/ls-extensions/bre-libs") {
             into "bre/lib/"
         }
@@ -278,34 +321,32 @@ task copyOtherRepos(type: Copy) {
 
 task buildDistRepo(type: JavaExec) {
     classpath = project.configurations.repoBuilder
-    main = 'io.ballerina.dist.DistRepoBuilder'
-    args "$buildDir/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+    mainClass = 'io.ballerina.dist.DistRepoBuilder'
+    args layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}").get().asFile.toString()
 }
 
 task copyDevToolsCoverageReport(type: Copy) {
-    from "$project.buildDir/target/extracted-distributions/ballerina-dev-tools-zip/tests/testerina-report-tools-${devToolsVersion}.zip"
-    into "$project.buildDir/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/lib/tools/coverage"
+    from layout.buildDirectory.file("target/extracted-distributions/ballerina-dev-tools-zip/tests/testerina-report-tools-${devToolsVersion}.zip").get().asFile
+    into layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/lib/tools/coverage").get().asFile
     rename("testerina-report-tools-${devToolsVersion}.zip", "report.zip")
 }
 
 task copyDevToolsDocUi(type: Copy) {
-    from zipTree("$project.buildDir/target/extracted-distributions/doc-ui-zip/ballerina-doc-ui.zip")
-    into "$project.buildDir/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/lib/tools/doc-ui"
+    from zipTree(layout.buildDirectory.file("target/extracted-distributions/doc-ui-zip/ballerina-doc-ui.zip").get().asFile)
+    into layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/lib/tools/doc-ui").get().asFile
 }
 
 task filterApiDocs(type: Delete) {
-    delete "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/docs/ballerina/lang.__internal"
-    delete "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/docs/ballerina/lang.annotations"
+    delete layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/docs/ballerina/lang.__internal").get().asFile
+    delete layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/docs/ballerina/lang.annotations").get().asFile
 }
 
 task combineDocs(type: Exec) {
-    workingDir "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/docs"
+    workingDir layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/docs").get().asFile
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine 'cmd', '/c', "$project.buildDir/target/extracted-distributions/jballerina-tools-zip/" +
-                "jballerina-tools-${ballerinaLangVersion}/bin/bal.bat", "doc", "--combine"
+        commandLine 'cmd', '/c', layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin").get().asFile.toString() + "/bal.bat", "doc", "--combine"
     } else {
-        commandLine "$project.buildDir/target/extracted-distributions/jballerina-tools-zip/" +
-                "jballerina-tools-${ballerinaLangVersion}/bin/bal", "doc", "--combine"
+        commandLine layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin").get().asFile.toString() + "/bal", "doc", "--combine"
     }
 }
 
@@ -328,7 +369,7 @@ task packageDist(type: Zip) {
     }
     into("${parentDir}/examples") {
         from "${project.rootDir}/examples/"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     // Code2Cloud Extension Examples
     into("${parentDir}/examples") {
@@ -339,7 +380,7 @@ task packageDist(type: Zip) {
     /* Files */
     into("${parentDir}/lib/") {
         from "lib/version.txt"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: version])
     }
     /* Dependencies */
@@ -370,7 +411,7 @@ task packageDistZip(type: Zip) {
 
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     // Code2Cloud Extension Examples
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
@@ -400,32 +441,32 @@ task packageDistZip(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bin") {
         from "lib/version.txt"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: shortVersion])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: shortVersion])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/installer-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [uuid: installerVersion])
     }
     into("${parentDir}/bin") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/bin/bal"
-        fileMode = 0775
+        filePermissions { unix(0775) }
         filter(ReplaceTokens, tokens: [ballerinaCommandVersion: ballerinaCommandVersion])
     }
     into("${parentDir}/bin") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/bin/bal.bat"
-        fileMode = 0775
+        filePermissions { unix(0775) }
         filter(ReplaceTokens, tokens: [ballerinaCommandVersion: ballerinaCommandVersion])
     }
     into("${parentDir}/lib") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/lib/ballerina-command-${ballerinaCommandVersion}.jar"
-        fileMode = 0775
+        filePermissions { unix(0775) }
     }
     /* Dependencies */
     into("${parentDir}/distributions/ballerina-${shortVersion}/bre/lib") {
@@ -451,11 +492,11 @@ task packageDistLinux(type: Zip) {
 
     into("${parentDir}/dependencies") {
         from "build/target/extracted-jre-linux"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     // Code2Cloud Extension Examples
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
@@ -485,35 +526,35 @@ task packageDistLinux(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bin") {
         from "lib/version.txt"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: version])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: shortVersion])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/installer-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [uuid: installerVersion])
     }
     into("${parentDir}/bin") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/bin/bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
         filter(ReplaceTokens, tokens: [ballerinaCommandVersion: ballerinaCommandVersion])
     }
     into("${parentDir}/lib") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/lib/ballerina-command-${ballerinaCommandVersion}.jar"
-        fileMode = 0775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/bal_completion.bash"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/_bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
 
     /* Dependencies */
@@ -540,11 +581,11 @@ task packageDistLinuxArm(type: Zip) {
 
     into("${parentDir}/dependencies") {
         from "build/target/extracted-jre-linux-arm"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     // Code2Cloud Extension Examples
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples") {
@@ -574,35 +615,35 @@ task packageDistLinuxArm(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bin") {
         from "lib/version.txt"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: version])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: shortVersion])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/installer-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [uuid: installerVersion])
     }
     into("${parentDir}/bin") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/bin/bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
         filter(ReplaceTokens, tokens: [ballerinaCommandVersion: ballerinaCommandVersion])
     }
     into("${parentDir}/lib") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/lib/ballerina-command-${ballerinaCommandVersion}.jar"
-        fileMode = 0775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/bal_completion.bash"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/_bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
 
     /* Dependencies */
@@ -629,11 +670,11 @@ task packageDistMac(type: Zip) {
 
     into("${parentDir}/dependencies") {
         from "build/target/extracted-jre-macos"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
 
     // Code2Cloud Extension Examples
@@ -658,36 +699,36 @@ task packageDistMac(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bin") {
         from "lib/version.txt"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: version])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: shortVersion])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/installer-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [uuid: installerVersion])
     }
     into("${parentDir}/bin") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/bin/bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
         filter(ReplaceTokens, tokens: [ballerinaCommandVersion: ballerinaCommandVersion])
     }
     into("${parentDir}/lib") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}" +
                 "/lib/ballerina-command-${ballerinaCommandVersion}.jar"
-        fileMode = 0775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/bal_completion.bash"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/_bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
 
     /* Dependencies */
@@ -714,11 +755,11 @@ task packageDistMacArm(type: Zip) {
 
     into("${parentDir}/dependencies") {
         from "build/target/extracted-jre-macos-arm"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
 
     // Code2Cloud Extension Examples
@@ -743,36 +784,36 @@ task packageDistMacArm(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bin") {
         from "lib/version.txt"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: version])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: shortVersion])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/installer-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [uuid: installerVersion])
     }
     into("${parentDir}/bin") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/bin/bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
         filter(ReplaceTokens, tokens: [ballerinaCommandVersion: ballerinaCommandVersion])
     }
     into("${parentDir}/lib") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}" +
                 "/lib/ballerina-command-${ballerinaCommandVersion}.jar"
-        fileMode = 0775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/bal_completion.bash"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
     into("${parentDir}/scripts") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/scripts/_bal"
-        fileMode = 775
+        filePermissions { unix(0775) }
     }
 
     /* Dependencies */
@@ -799,11 +840,11 @@ task packageDistWindows(type: Zip) {
 
     into("${parentDir}/dependencies") {
         from "build/target/extracted-jre-windows"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/examples/") {
         from "${project.rootDir}/examples/"
-        fileMode = 0755
+        filePermissions { unix(0755) }
     }
 
     // Code2Cloud Extension Examples
@@ -828,27 +869,27 @@ task packageDistWindows(type: Zip) {
     }
     into("${parentDir}/distributions/ballerina-${shortVersion}/bin") {
         from "lib/version.txt"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: version])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/ballerina-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [version: shortVersion])
     }
     into("${parentDir}/distributions") {
         from "../resources/tools/distributions/installer-version"
-        fileMode = 0644
+        filePermissions { unix(0644) }
         filter(ReplaceTokens, tokens: [uuid: installerVersion])
     }
     into("${parentDir}/bin") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/bin/bal.bat"
-        fileMode = 775
+        filePermissions { unix(0775) }
         filter(ReplaceTokens, tokens: [ballerinaCommandVersion: ballerinaCommandVersion])
     }
     into("${parentDir}/lib") {
         from "build/target/ballerina-command-${ballerinaCommandVersion}/lib/ballerina-command-${ballerinaCommandVersion}.jar"
-        fileMode = 0775
+        filePermissions { unix(0775) }
     }
 
     /* Dependencies */
@@ -881,6 +922,7 @@ artifacts {
 task testExamples() {
     def distPath = "${project.rootDir}/ballerina/build/target/extracted-distributions/ballerina-${version}-${codeName}"
     def bbeList = []
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
 
     PatternSet patternSet = new PatternSet()
     patternSet.exclude("**/.ballerina/**")
@@ -917,13 +959,13 @@ task testExamples() {
     ext.prepareProject = { bbe ->
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             //TODO: Need to verify with windows
-            exec {
+            execHelper.execOperations.exec {
                 workingDir "${distPath}/${bbe}"
                 commandLine 'cmd', '/c', "${distPath}/bin/bal.bat init test"
             }
 
         } else {
-            exec {
+            execHelper.execOperations.exec {
                 workingDir "${distPath}/${bbe}"
                 commandLine 'sh', '-c', "${distPath}/bin/bal init test"
             }
@@ -941,13 +983,13 @@ task testExamples() {
                     def grpcCommand =  "grpc --input ${it.name} --output ."
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         //TODO: Need to verify with windows
-                        exec {
+                        execHelper.execOperations.exec {
                             workingDir "${distPath}/${bbe}"
                             commandLine 'cmd', '/c', "${distPath}/bin/bal.bat ${grpcCommand}"
                         }
 
                     } else {
-                        exec {
+                        execHelper.execOperations.exec {
                             workingDir "${distPath}/${bbe}"
                             commandLine 'sh', '-c', "${distPath}/bin/bal ${grpcCommand}"
                         }
@@ -964,14 +1006,14 @@ task testExamples() {
         println "Building example '${bbe.url}'"
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             //TODO: Need to verify with windows
-            exitVal = exec {
+            exitVal = execHelper.execOperations.exec {
                 ignoreExitValue true
                 workingDir "${distPath}/${bbe.url}"
                 commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'build', "${additionalParams}"
                 commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'test', "${additionalParams}"
             }
         } else {
-            exitVal = exec {
+            exitVal = execHelper.execOperations.exec {
                 ignoreExitValue true
                 workingDir "${distPath}/${bbe.url}"
                 commandLine 'sh', '-c', "${distPath}/bin/bal build ${additionalParams}"
@@ -1049,14 +1091,14 @@ task testExamples() {
             def scriptPath = "${project.rootDir}/ballerina/lib"
             def exitVal
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                exitVal = exec {
+                exitVal = execHelper.execOperations.exec {
                     def windowsPath = scriptPath.replace('/', '\\')
                     workingDir "$windowsPath"
                     commandLine "$windowsPath\\run.bat", "${directoryPath}", "${distPath}/bin/bal.bat", "${balName}", "${curlCommandsFilePath}", "${portFilePath}", "${additionalBuildParams}"
                     ignoreExitValue true
                 }
             } else {
-                exitVal = exec {
+                exitVal = execHelper.execOperations.exec {
                     workingDir "$scriptPath"
                     commandLine "bash", "run.sh", "${directoryPath}", "${distPath}/bin/./bal", "${balName}", "${curlCommandsFilePath}", "${portFilePath}", "${additionalBuildParams}"
                     ignoreExitValue true
@@ -1089,7 +1131,7 @@ task testExamples() {
             new ByteArrayOutputStream().withStream { os ->
                 println "Output Verification '${bbe.url}'"
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    exec {
+                    execHelper.execOperations.exec {
                         workingDir "${directoryPath}"
                         commandLine 'cmd', '/c', "${distPath}/bin/bal.bat", 'run', "${balName}.bal ", ${additionalBuildParams}
                         ignoreExitValue true
@@ -1097,7 +1139,7 @@ task testExamples() {
                         errorOutput = errOut
                     }
                 } else {
-                    exec {
+                    execHelper.execOperations.exec {
                         workingDir "${directoryPath}"
                         commandLine 'sh', '-c', "${distPath}/bin/bal run ${balName}.bal ${additionalBuildParams}"
                         ignoreExitValue true
@@ -1192,11 +1234,13 @@ task testExamples() {
 def addH2Dependency = { filePath ->
     // Add the H2 database dependency to Ballerina.toml file
     def tomlFile = new File(filePath)
-    tomlFile.append("\n\n[[platform.java21.dependency]]")
+    tomlFile.append("\n\n[[platform.java25.dependency]]")
     tomlFile.append("\nartifactId = \"h2\"")
     tomlFile.append("\nversion = \"2.2.224\"")
     tomlFile.append("\ngroupId = \"com.h2database\"")
 }
+
+def stdlibsExecHelper = project.objects.newInstance(BallerinaExecHelper)
 
 def buildAndTestStandardLibs = { distPath, stdlibTest, isStageTest, testMinorVersionDifference ->
     def exitVal
@@ -1215,7 +1259,7 @@ def buildAndTestStandardLibs = { distPath, stdlibTest, isStageTest, testMinorVer
         if (!isStageTest) {
             def tomlFile = new File("${distPath}/${stdlibTest}/Ballerina.toml")
             if (!tomlFile.exists()) {
-                exec {
+                stdlibsExecHelper.execOperations.exec {
                     workingDir "${distPath}/${stdlibTest}"
                     commandLine 'cmd', '/c', "${distPath}/bin/bal.bat init test"
                 }
@@ -1224,18 +1268,18 @@ def buildAndTestStandardLibs = { distPath, stdlibTest, isStageTest, testMinorVer
                 addH2Dependency("${distPath}/${stdlibTest}/Ballerina.toml")
             }
         } else {
-            exec {
+            stdlibsExecHelper.execOperations.exec {
                 workingDir "${distPath}/${stdlibTest}"
                 commandLine 'cmd', '/c', "${distPath}/bin/bal.bat clean"
             }
         }
         if (testMinorVersionDifference) {
-            exec {
+            stdlibsExecHelper.execOperations.exec {
                 workingDir "${distPath}/${stdlibTest}"
                 commandLine 'cmd', '/c', "rm Dependencies.toml"
             }
         }
-        exitVal = exec {
+        exitVal = stdlibsExecHelper.execOperations.exec {
             ignoreExitValue true
             workingDir "${distPath}/${stdlibTest}"
             commandLine 'cmd', '/c', "${distPath}/bin/bal.bat test ${additionalBuildParams}"
@@ -1244,7 +1288,7 @@ def buildAndTestStandardLibs = { distPath, stdlibTest, isStageTest, testMinorVer
         if (!isStageTest) {
             def tomlFile = new File("${distPath}/${stdlibTest}/Ballerina.toml")
             if (!tomlFile.exists()) {
-                exec {
+                stdlibsExecHelper.execOperations.exec {
                     workingDir "${distPath}/${stdlibTest}"
                     commandLine 'sh', '-c', "${distPath}/bin/bal init test"
                 }
@@ -1253,18 +1297,18 @@ def buildAndTestStandardLibs = { distPath, stdlibTest, isStageTest, testMinorVer
                 addH2Dependency("${distPath}/${stdlibTest}/Ballerina.toml")
             }
         } else {
-            exec {
+            stdlibsExecHelper.execOperations.exec {
                 workingDir "${distPath}/${stdlibTest}"
                 commandLine 'sh', '-c', "${distPath}/bin/bal clean"
             }
         }
         if (testMinorVersionDifference) {
-            exec {
+            stdlibsExecHelper.execOperations.exec {
                 workingDir "${distPath}/${stdlibTest}"
                 commandLine 'sh', '-c', "rm Dependencies.toml"
             }
         }
-        exitVal = exec {
+        exitVal = stdlibsExecHelper.execOperations.exec {
             environment "BALLERINA_STAGE_CENTRAL", "$isStageTest"
             ignoreExitValue true
             workingDir "${distPath}/${stdlibTest}"
@@ -1371,6 +1415,7 @@ task testStdlibsWithStaging() {
 task testDevToolsIntegration() {
     def distPath = "${project.rootDir}/ballerina/build/target/extracted-distributions/ballerina-${version}-${codeName}"
     def devtoolsProjectList = []
+    def devToolsExecHelper = project.objects.newInstance(BallerinaExecHelper)
 
     PatternSet patternSet = new PatternSet()
     patternSet.exclude("**/.ballerina/**")
@@ -1414,22 +1459,22 @@ task testDevToolsIntegration() {
                 def additionalBuildParams = ""
 
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    exec {
-                        workingDir "${buildDir}/${devtoolsProject}"
+                    devToolsExecHelper.execOperations.exec {
+                        workingDir layout.buildDirectory.dir(devtoolsProject).get().asFile
                         commandLine 'cmd', '/c', "${distPath}/bin/bal.bat init test"
                     }
-                    exec {
-                        workingDir "${buildDir}/${devtoolsProject}"
+                    devToolsExecHelper.execOperations.exec {
+                        workingDir layout.buildDirectory.dir(devtoolsProject).get().asFile
                         commandLine 'cmd', '/c',
                                 "${distPath}/bin/bal.bat test ${additionalBuildParams}"
                     }
                 } else {
-                    exec {
+                    devToolsExecHelper.execOperations.exec {
                         workingDir "${distPath}/${devtoolsProject}"
                         commandLine 'sh', '-c',
                                 "${distPath}/bin/bal init test"
                     }
-                    exec {
+                    devToolsExecHelper.execOperations.exec {
                         workingDir "${distPath}/${devtoolsProject}"
                         commandLine 'sh', '-c',
                                 "${distPath}/bin/bal test ${additionalBuildParams}"
@@ -1442,10 +1487,11 @@ task testDevToolsIntegration() {
 }
 
 task generateCache(dependsOn: ':cache-generator:build') {
+    def cacheExecHelper = project.objects.newInstance(BallerinaExecHelper)
     doFirst {
         copy {
             from "${project.rootDir}/cache-generator/build/libs/cache-generator-${project.version}.jar"
-            into "$buildDir/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bre/lib"
+            into layout.buildDirectory.dir("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bre/lib").get().asFile
         }
     }
 
@@ -1478,9 +1524,10 @@ task generateCache(dependsOn: ':cache-generator:build') {
             configStdlibs.add(artifact.name + "-zip")
         }
 
+        def buildDirPath = layout.buildDirectory.get().asFile.toString()
         sortedLibs.each { lib ->
             if (configStdlibs.contains(lib)) {
-                def versionList = [file(file("${buildDir}/target/extracted-distributions/" + lib +
+                def versionList = [file(file("${buildDirPath}/target/extracted-distributions/" + lib +
                         "/bala").listFiles()[0].toString() + "/" + lib.split("-")[0]).listFiles()[0].name]
                 dependencyMap["${lib}"] = versionList
             }
@@ -1488,7 +1535,7 @@ task generateCache(dependsOn: ':cache-generator:build') {
 
         sortedLibs.each { lib ->
             if (configStdlibs.contains(lib)) {
-                def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + lib
+                def artifactExtractedPath = "${buildDirPath}/target/extracted-distributions/" + lib
                 String balaDir = artifactExtractedPath + "/bala"
 
                 new File("${balaDir}").listFiles().each { orgDirFile ->
@@ -1496,17 +1543,17 @@ task generateCache(dependsOn: ':cache-generator:build') {
                     String moduleDir = new File("${orgDir}").listFiles()[0].toString()
                     String versionDir = new File("${moduleDir}").listFiles()[0].toString()
                     String balaPath = new File("${versionDir}").listFiles()[0].toString()
-                    String jbalPath = "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+                    String jbalPath = "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
 
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                        exec {
-                            workingDir "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+                        cacheExecHelper.execOperations.exec {
+                            workingDir "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
                             commandLine 'cmd', '/c', "${distPath}/bin/bal.bat gencache ${balaPath} ${jbalPath}"
                             ignoreExitValue true
                         }
                     } else {
-                        exec {
-                            workingDir "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+                        cacheExecHelper.execOperations.exec {
+                            workingDir "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
                             commandLine 'sh', '-c', "${distPath}/bin/bal gencache ${balaPath} ${jbalPath}"
                             ignoreExitValue true
                         }
@@ -1530,25 +1577,25 @@ task generateCache(dependsOn: ':cache-generator:build') {
 
         /* C2C Libraries */
         configurations.ballerinaC2cLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+            def artifactExtractedPath = "${buildDirPath}/target/extracted-distributions/" + artifact.name + "-zip"
             String balaDir = artifactExtractedPath + "/bala"
 
             String orgDir = new File("${balaDir}").listFiles()[0].toString()
             String moduleDir = new File("${orgDir}").listFiles()[0].toString()
             String versionDir = new File("${moduleDir}").listFiles()[0].toString()
             String balaPath = new File("${versionDir}").listFiles()[0].toString()
-            String jbalPath = "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+            String jbalPath = "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
 
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                exec {
-                    workingDir "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+                cacheExecHelper.execOperations.exec {
+                    workingDir "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
                     commandLine 'cmd', '/c', "${distPath}/bin/bal.bat gencache ${balaPath} ${jbalPath}"
                     ignoreExitValue true
                 }
             }
             else {
-                exec {
-                    workingDir "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+                cacheExecHelper.execOperations.exec {
+                    workingDir "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
                     commandLine 'sh', '-c', "${distPath}/bin/bal gencache ${balaPath} ${jbalPath}"
                     ignoreExitValue true
                 }
@@ -1557,31 +1604,31 @@ task generateCache(dependsOn: ':cache-generator:build') {
 
         /* OpenAPI Module */
         configurations.openapiModule.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
+            def artifactExtractedPath = "${buildDirPath}/target/extracted-distributions/" + artifact.name + "-zip"
             String balaDir = artifactExtractedPath + "/bala"
 
             String orgDir = new File("${balaDir}").listFiles()[0].toString()
             String moduleDir = new File("${orgDir}").listFiles()[0].toString()
             String versionDir = new File("${moduleDir}").listFiles()[0].toString()
             String balaPath = new File("${versionDir}").listFiles()[0].toString()
-            String jbalPath = "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+            String jbalPath = "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
 
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                exec {
-                    workingDir "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+                cacheExecHelper.execOperations.exec {
+                    workingDir "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
                     commandLine 'cmd', '/c', "${distPath}/bin/bal.bat gencache ${balaPath} ${jbalPath}"
                     ignoreExitValue true
                 }
             }
             else {
-                exec {
-                    workingDir "${buildDir}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+                cacheExecHelper.execOperations.exec {
+                    workingDir "${buildDirPath}/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
                     commandLine 'sh', '-c', "${distPath}/bin/bal gencache ${balaPath} ${jbalPath}"
                     ignoreExitValue true
                 }
             }
         }
-        delete "$buildDir/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bre/lib/cache-generator-${project.version}.jar"
+        delete layout.buildDirectory.file("target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bre/lib/cache-generator-${project.version}.jar").get().asFile
         delete "${project.rootDir}/cache-generator/build/libs/cache-generator-${project.version}.jar"
         delete "${project.rootDir}/module_list.json"
     }
@@ -1620,13 +1667,13 @@ task generateBalToolsToml () {
         }
 
         def balToolsTomlString = ""
-        String balToolsTomlPath = "${buildDir}/target/extracted-distributions/" +
-                "jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/resources/bal-tools.toml"
+        String balToolsTomlPath = layout.buildDirectory.dir("target/extracted-distributions/" +
+                "jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/resources").get().asFile.toString() + "/bal-tools.toml"
         def file = new File(balToolsTomlPath)
 
         configBalTools.each { lib ->
             if (sortedLibs.contains(lib)) {
-                def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + lib
+                def artifactExtractedPath = layout.buildDirectory.dir("target/extracted-distributions/" + lib).get().asFile.toString()
                 String balaDir = artifactExtractedPath + "/bala"
 
                 new File("${balaDir}").listFiles().each { orgDirFile ->
@@ -1653,6 +1700,13 @@ task generateBalToolsToml () {
         file.write(balToolsTomlString)
     }
 }
+
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
+}
+
+build.dependsOn patchBallerinaScripts
+test.dependsOn patchBallerinaScripts
 
 /* Unpack Dependencies */
 unpackJballerinaTools.dependsOn unpackBallerinaJre

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -1723,6 +1723,12 @@ build.dependsOn patchBallerinaScripts
 test.dependsOn patchBallerinaScripts
 buildDistRepo.dependsOn patchBallerinaScripts
 
+// Gradle 9 no longer auto-wires `assemble` to build artifacts of bareword-declared
+// configurations (jBallerinaDistribution, ballerinaDistribution, etc. above), unlike
+// Gradle 8.2.1 used on master. Wire it explicitly so `assemble`/`build -x check` still
+// produce the distribution zips.
+assemble.dependsOn packageDistWindows
+
 /* Unpack Dependencies */
 unpackJballerinaTools.dependsOn unpackBallerinaJre
 unpackDevTools.dependsOn unpackJballerinaTools

--- a/build-time-tests/build.gradle
+++ b/build-time-tests/build.gradle
@@ -14,6 +14,13 @@
  ~ * limitations under the License.
  ~ */
 
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class BuildTimeTestsExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
 description = 'Ballerina - Build Time Tests'
 
 apply plugin: 'java'
@@ -42,9 +49,10 @@ task buildSamples {
     dependsOn copySamples
     dependsOn configurations.ballerinaDistribution
     dependsOn (":ballerina:unzipDistForTests")
+    def execHelper = project.objects.newInstance(BuildTimeTestsExecHelper)
     doLast {
-        exec {
-            workingDir "${buildDir}/samples"
+        execHelper.execOperations.exec {
+            workingDir layout.buildDirectory.dir("samples").get().asFile
             commandLine 'sh', '-c', "bash build-samples.sh $distPath"
         }
     }
@@ -53,6 +61,6 @@ task buildSamples {
 task processData(type: JavaExec) {
     dependsOn buildSamples
     classpath = sourceSets.main.runtimeClasspath
-    setMain('org.ballerina.packages.buildtime.GenerateBuildDataCsv')
+    mainClass = 'org.ballerina.packages.buildtime.GenerateBuildDataCsv'
     args "$buildDir/../../ballerina/build/distributions"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,10 @@
 plugins {
     id 'base'
     id 'maven-publish'
-    id 'net.researchgate.release' version '2.8.0'
+    id 'net.researchgate.release' version '3.1.0'
     id 'de.undercouch.download' version '5.4.0'
     id "com.github.johnrengelman.shadow" version "8.1.1"
-    id "com.github.spotbugs" version "5.0.14"
+    id "com.github.spotbugs" version "6.5.1"
 }
 
 description = 'Ballerina - Tools - Parent'
@@ -70,10 +70,16 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    sourceCompatibility = 21
-    targetCompatibility = 21
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
+    }
+
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
     }
 
     buildscript {

--- a/cache-generator/build.gradle
+++ b/cache-generator/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         transitive = false
     }
 }
-def bDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def bDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 
 shadowJar {
     configurations = [project.configurations.runtimeClasspath]

--- a/cache-generator/src/main/java/io/ballerina/gencache/cmd/GenCacheCmd.java
+++ b/cache-generator/src/main/java/io/ballerina/gencache/cmd/GenCacheCmd.java
@@ -81,7 +81,7 @@ public class GenCacheCmd implements BLauncherCmd{
             if (diagnosticResult.hasErrors()) {
                 return;
             }
-            JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_21);
+            JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_25);
             diagnosticResult = jBallerinaBackend.diagnosticResult();
             for (Diagnostic diagnostic : diagnosticResult.diagnostics()) {
                 outStream.println(diagnostic.toString());

--- a/config/checkstyle/build.gradle
+++ b/config/checkstyle/build.gradle
@@ -26,7 +26,7 @@ task downloadMultipleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {

--- a/devtools-integration-tests/build.gradle
+++ b/devtools-integration-tests/build.gradle
@@ -48,9 +48,9 @@ task devToolsIntegrationTest {
     dependsOn configurations.ballerinaWindowsDistribution
     test {
         systemProperty "distributions.dir", "$buildDir/../../ballerina/build/distributions"
-        systemProperty "target.dir", "$buildDir"
+        systemProperty "target.dir", layout.buildDirectory.get().asFile.toString()
         systemProperty "maven.version", "$version"
-        systemProperty "examples.dir", "$buildDir/../../examples"
+        systemProperty "examples.dir", layout.buildDirectory.get().asFile.toString() + "/../../examples"
         systemProperty "line.check.extensions", ".java, .bal"
         systemProperty "short.version", "$version".split("-")[0]
         systemProperty "server.zip", "$buildDir/../../ballerina/build/distributions/ballerina-${shortVersion}.zip"

--- a/dist-repo-builder/src/main/java/io/ballerina/dist/DistRepoBuilder.java
+++ b/dist-repo-builder/src/main/java/io/ballerina/dist/DistRepoBuilder.java
@@ -135,7 +135,7 @@ public class DistRepoBuilder {
             valid = false;
         }
         // Check if module jar exists
-        Path jar = repo.resolve("cache").resolve(orgName).resolve(moduleName).resolve(version).resolve("java21")
+        Path jar = repo.resolve("cache").resolve(orgName).resolve(moduleName).resolve(version).resolve("java25")
                 .resolve(getJarName(orgName, moduleName, version));
         if (!Files.exists(jar)) {
             System.out.println("Jar missing for package :" + orgName + "/" + moduleName);

--- a/docs/build-ballerina-from-source.md
+++ b/docs/build-ballerina-from-source.md
@@ -11,7 +11,7 @@
 
 Follow the steps below to set up the prerequisites.
 
-1. Download and [set up](https://adoptopenjdk.net/installation.html) OpenJDK 21 ([Adopt OpenJDK](https://adoptopenjdk.net/) or any other OpenJDK distribution).
+1. Download and [set up](https://adoptopenjdk.net/installation.html) OpenJDK 25 ([Adopt OpenJDK](https://adoptopenjdk.net/) or any other OpenJDK distribution).
 
    >**Info:** You can also use [Oracle JDK](https://www.oracle.com/java/technologies/javase-downloads.html).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ group=org.ballerinalang
 version=2201.14.0-SNAPSHOT
 codeName=swan-lake
 
-ballerinaLangVersion=2201.14.0-20260708-154000-772af27e
-ballerinaJreVersion=3.0.0
-dependencyJREVersion=jdk-21.0.5+11-jre
+ballerinaLangVersion=2201.14.0-20260714-113900-d799d08b
+ballerinaJreVersion=4.0.0
+dependencyJREVersion=jdk-25.0.3+9-jre
 specVersion=2024R1
 slf4jVersion=1.7.30
 balstdlibBranch=master
@@ -88,7 +88,7 @@ openapiModuleVersion=2.4.0
 
 # Dev Tools
 devToolsVersion=2.6.1
-ballerinaCommandVersion=1.5.1
+ballerinaCommandVersion=1.6.0
 
 # API Doc UI
 docUiApi=https://api.dev-central.ballerina.io/2.0/docs/doc-ui

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ group=org.ballerinalang
 version=2201.14.0-SNAPSHOT
 codeName=swan-lake
 
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.14.0-20260708-154000-772af27e
 ballerinaJreVersion=3.0.0
 dependencyJREVersion=jdk-21.0.5+11-jre
 specVersion=2024R1

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ group=org.ballerinalang
 version=2201.14.0-SNAPSHOT
 codeName=swan-lake
 
-ballerinaLangVersion=2201.14.0-20260513-003900-6983b294f4c
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 ballerinaJreVersion=3.0.0
 dependencyJREVersion=jdk-21.0.5+11-jre
 specVersion=2024R1

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ devIdpUrl=https://dev.api.asgardeo.io/oauth2/token/.well-known/openid-configurat
 
 # Stdlib Level 01
 stdlibIoVersion=1.8.0
-stdlibJavaArraysVersion=1.6.0
+stdlibJavaArraysVersion=1.6.1
 stdlibTimeVersion=2.8.0
 stdlibUrlVersion=2.6.1
 stdlibXmldataVersion=2.9.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -103,3 +103,4 @@ asyncapiToolVersion=0.12.0
 c2cVersion=4.0.0-20250915-120000-41c6c17
 
 installerVersion=500db315-7e0b-4ae3-8780-bdb358f81cfd
+jacocoVersion=0.8.14

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -66,18 +66,16 @@ dependencies {
     checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 jacoco {
-    toolVersion = "0.8.10"
+    toolVersion = "0.8.13"
 }
 
 test {
-    systemProperty "ballerina.home", "$buildDir"
+    systemProperty "ballerina.home", layout.buildDirectory.get().asFile.toString()
     systemProperty "org.apache.commons.logging.Log", "org.apache.commons.logging.impl.NoOpLog"
     testLogging {
         showStackTraces = true
@@ -87,7 +85,7 @@ test {
     }
     jacoco {
         enabled = true
-        destinationFile = file("$buildDir/coverage-reports/jacoco.exec")
+        destinationFile = layout.buildDirectory.file("coverage-reports/jacoco.exec").get().asFile
         includeNoLocationClasses = true
         excludes = ['jdk.internal.*']
     }
@@ -106,13 +104,13 @@ spotbugsMain {
     ignoreFailures = true
     effort = "max"
     reportLevel = "low"
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = false
+        text.required = false
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,4 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/language-server-simulator/build.gradle
+++ b/language-server-simulator/build.gradle
@@ -37,19 +37,18 @@ dependencies {
 task unpackBallerinaDistribution(type: Copy) {
     dependsOn configurations.jBallerinaDistribution
     dependsOn configurations.ballerinaDistribution
-    def sourceDir = "${buildDir}/${distributionDir}"
+    def sourceDir = layout.buildDirectory.dir(distributionDir).get().asFile
     from zipTree { "${rootDir}/ballerina/build/distributions/ballerina-${version}-swan-lake.zip" }
-    new File("${sourceDir}").mkdirs()
-    into new File("${sourceDir}")
+    sourceDir.mkdirs()
+    into sourceDir
 }
 
 task copyPackages() {
     dependsOn unpackBallerinaDistribution
-    def sourceDir = "${buildDir}/${distributionDir}" +
-            "/ballerina-${version}-swan-lake/distributions/ballerina-${shortVersion}/repo"
+    def sourceDir = layout.buildDirectory.dir("${distributionDir}/ballerina-${version}-swan-lake/distributions/ballerina-${shortVersion}/repo").get().asFile
     copy {
         from "${sourceDir}"
-        into "${buildDir}/repo"
+        into layout.buildDirectory.dir("repo").get().asFile
     }
 }
 
@@ -57,40 +56,40 @@ task downloadBalTestProject(type: Download) {
     // Download nBallerina latest tag
     src "https://github.com/ballerina-platform/nballerina/archive/refs/heads/main.zip"
     onlyIfModified true
-    dest new File("${buildDir}/nballeirna-src.zip")
+    dest layout.buildDirectory.file("nballeirna-src.zip").get().asFile
 }
 
 task downloadBalFHIRTestProject(type: Download) {
     // Download nBallerina latest tag
     src "https://github.com/ballerina-platform/module-ballerinax-health.fhir.r4/archive/refs/tags/uscore-v1.0.5.zip"
     onlyIfModified true
-    dest new File("${buildDir}/fhir-src.zip")
+    dest layout.buildDirectory.file("fhir-src.zip").get().asFile
 }
 
 task unpackBalTestProject(type: Copy) {
     dependsOn downloadBalTestProject
-    def sourceDir = "${buildDir}/${nbalSourceDir}"
-    from zipTree { "${buildDir}/nballeirna-src.zip" }
-    new File("${sourceDir}").mkdirs()
-    into new File("${sourceDir}")
+    def sourceDir = layout.buildDirectory.dir(nbalSourceDir).get().asFile
+    from zipTree { layout.buildDirectory.file("nballeirna-src.zip").get().asFile }
+    sourceDir.mkdirs()
+    into sourceDir
 }
 
 task unpackBalFHIRTestProject(type: Copy) {
     dependsOn downloadBalFHIRTestProject
-    def sourceDir = "${buildDir}/${fhirSourceDir}"
-    from zipTree { "${buildDir}/fhir-src.zip" }
-    new File("${sourceDir}").mkdirs()
-    into new File("${sourceDir}")
+    def sourceDir = layout.buildDirectory.dir(fhirSourceDir).get().asFile
+    from zipTree { layout.buildDirectory.file("fhir-src.zip").get().asFile }
+    sourceDir.mkdirs()
+    into sourceDir
 }
 
 task runLSSimulatorOnnBallerina(type: JavaExec) {
     dependsOn copyPackages
     dependsOn unpackBalTestProject
 
-    def extractedBalSrcDir = "${buildDir}/${nbalSourceDir}/nballerina-main/compiler"
+    def extractedBalSrcDir = layout.buildDirectory.dir("${nbalSourceDir}/nballerina-main/compiler").get().asFile
     systemProperty "ls.simulation.src", "${extractedBalSrcDir}"
 
-    systemProperty "ballerina.home", "$buildDir/"
+    systemProperty "ballerina.home", layout.buildDirectory.get().asFile.toString() + "/"
     systemProperty "ballerina.version", "${ballerinaLangVersion}"
     systemProperty "ls.simulation.duration", "60"
     systemProperty "ls.simulation.skipGenerators", System.getProperty("ls.simulation.skipGenerators")
@@ -102,17 +101,17 @@ task runLSSimulatorOnnBallerina(type: JavaExec) {
     group = "Execution"
     description = "Run the main class with JavaExecTask"
     classpath = sourceSets.main.runtimeClasspath
-    main = "org.ballerinalang.langserver.simulator.EditorSimulator"
+    mainClass = "org.ballerinalang.langserver.simulator.EditorSimulator"
 }
 
 task runLSSimulatorOnFHIR(type: JavaExec) {
     dependsOn copyPackages
     dependsOn unpackBalFHIRTestProject
 
-    def extractedBalSrcDir = "${buildDir}/${fhirSourceDir}/module-ballerinax-health.fhir.r4-uscore-v1.0.5/base"
+    def extractedBalSrcDir = layout.buildDirectory.dir("${fhirSourceDir}/module-ballerinax-health.fhir.r4-uscore-v1.0.5/base").get().asFile
     systemProperty "ls.simulation.src", "${extractedBalSrcDir}"
 
-    systemProperty "ballerina.home", "$buildDir/"
+    systemProperty "ballerina.home", layout.buildDirectory.get().asFile.toString() + "/"
     systemProperty "ballerina.version", "${ballerinaLangVersion}"
     systemProperty "ls.simulation.duration", "60"
     systemProperty "ls.simulation.skipGenerators", System.getProperty("ls.simulation.skipGenerators")
@@ -124,7 +123,7 @@ task runLSSimulatorOnFHIR(type: JavaExec) {
     group = "Execution"
     description = "Run the main class with JavaExecTask"
     classpath = sourceSets.main.runtimeClasspath
-    main = "org.ballerinalang.langserver.simulator.EditorSimulator"
+    mainClass = "org.ballerinalang.langserver.simulator.EditorSimulator"
 }
 
 tasks.compileJava {

--- a/project-api-tests/build.gradle
+++ b/project-api-tests/build.gradle
@@ -52,9 +52,9 @@ task centralTests {
     dependsOn configurations.ballerinaWindowsDistribution
     test {
         systemProperty "distributions.dir", "$buildDir/../../ballerina/build/distributions"
-        systemProperty "target.dir", "$buildDir"
+        systemProperty "target.dir", layout.buildDirectory.get().asFile.toString()
         systemProperty "maven.version", "$version"
-        systemProperty "examples.dir", "$buildDir/../../examples"
+        systemProperty "examples.dir", layout.buildDirectory.get().asFile.toString() + "/../../examples"
         systemProperty "line.check.extensions", ".java, .bal"
         systemProperty "short.version", "$version".split("-")[0]
         systemProperty "server.zip", "$buildDir/../../ballerina/build/distributions/ballerina-${System.getProperty("short.version")}.zip"

--- a/project-api-tests/src/test/java/org/ballerina/projectapi/CentralTest.java
+++ b/project-api-tests/src/test/java/org/ballerina/projectapi/CentralTest.java
@@ -195,7 +195,7 @@ public class CentralTest {
         }
     }
 
-    @Test(description = "Build package B which has java21 platform dependency")
+    @Test(description = "Build package B which has java25 platform dependency")
     public void testBuildPackageB() throws IOException, InterruptedException {
         Process build = executePackCommand(DISTRIBUTION_FILE_NAME, this.tempWorkspaceDirectory.resolve(PROJECT_B),
                                        new LinkedList<>(), this.envVariables);

--- a/project-api-tests/src/test/java/org/ballerina/projectapi/CentralTestUtils.java
+++ b/project-api-tests/src/test/java/org/ballerina/projectapi/CentralTestUtils.java
@@ -68,7 +68,7 @@ public class CentralTestUtils {
     static final String COMMON_VERSION = "1.0.0";
     static final String TEST_PREFIX = "test_";
     static final String ANY_PLATFORM = "any";
-    static final String JAVA_PLATFORM = "java21";
+    static final String JAVA_PLATFORM = "java25";
     static final String BALLERINA_ARTIFACT_TYPE = "bala";
     static final String OUTPUT_NOT_CONTAINS_EXP_MSG = "build output does not contain expected message:";
     static final String PULLED_FROM_CENTRAL_MSG = " pulled from central successfully";

--- a/project-api-tests/src/test/resources/central/projectB/Ballerina.toml
+++ b/project-api-tests/src/test/resources/central/projectB/Ballerina.toml
@@ -4,10 +4,10 @@ name = "my_package"
 version = "1.0.0"
 readme = "Package.md"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible=true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "org.slf4j"
 artifactId = "slf4j-api"
 version = "1.7.30"

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@
 
 pluginManagement {
     repositories {
-        mavenLocal()
         gradlePluginPortal()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,8 +15,15 @@
  *
  */
 
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'ballerina-distribution'
@@ -33,12 +40,12 @@ project(':ballerina').projectDir = "$rootDir/ballerina" as File
 project(':ballerina-distribution-test').projectDir = "$rootDir/ballerina-test" as File
 project(':dist-repo-builder').projectDir = "$rootDir/dist-repo-builder" as File
 project(':cache-generator').projectDir = "$rootDir/cache-generator" as File
-project(':config').projectDir = "$rootDir config" as File
+project(':config').projectDir = "$rootDir/config" as File
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }
 include 'language-server-simulator'


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0; replace deprecated `fileMode` with `filePermissions`; replace deprecated `JavaExec.main` with `mainClass`
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade `ballerinaLangVersion` to `2201.14.0-20260527-050400-74f7e6bf`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack; wire `test.dependsOn patchBallerinaScripts` to ensure patching during split CI builds
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+)
- **JaCoCo 0.8.13**: Upgrade for Java 25 class file instrumentation support
- **CI workflow**: Update to JDK 25 via `actions/setup-java@v4`
- **Bug fix**: Correct `settings.gradle` projectDir path typo (missing `/` before `config`)

## Test plan
- [ ] `./gradlew build` passes green locally (full build including tests)
- [ ] CI passes on both Ubuntu and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request upgrades the Ballerina build and CI pipeline to Gradle 9.5.1 and Java 25. It improves compatibility across build, packaging, testing, and release workflows.

### Build and tooling updates
- Upgraded the Gradle wrapper to 9.5.1.
- Migrated Gradle Enterprise configuration to Develocity.
- Updated the release and SpotBugs plugins and JaCoCo configuration.
- Replaced deprecated Gradle APIs with `layout.buildDirectory`, `filePermissions`, `mainClass`, and injected `ExecOperations`.
- Corrected the `:config` project directory path.

### Java 25 alignment
- Configured Java 25 toolchains for subprojects.
- Updated Ballerina, JRE, dependency, and standard library versions.
- Updated platform references and test expectations from `java21` to `java25`.
- Updated cache generation to target Java 25.

### CI and documentation
- Updated build, test, installer, simulator, and release workflows to use Temurin JDK 25 with `actions/setup-java@v4`.
- Updated source-build documentation to require JDK 25.
- Corrected the language-server simulator archive filename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->