### PR TITLE
Add trivy ignore entries for jackson and netty CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,16 @@ CVE-2026-41907
 CVE-2025-48924
 CVE-2026-56740
 CVE-2026-56741
+
+# jackson-core / jackson-databind - needs dependency upgrade to 2.18.8+/2.21.4+
+GHSA-r7wm-3cxj-wff9
+CVE-2026-54512
+CVE-2026-54513
+CVE-2026-54514
+CVE-2026-54515
+CVE-2026-59888
+CVE-2026-59889
+GHSA-mhm7-754m-9p8w
+
+# netty-transport-native-epoll / netty-transport-native-kqueue - needs dependency upgrade to 4.1.135.Final/4.2.15.Final+
+CVE-2026-45536


### PR DESCRIPTION
## Purpose
The Trivy vulnerability scan step in the release pipeline is failing on the `2201.13.x` branch:
https://github.com/ballerina-platform/ballerina-distribution/actions/runs/31035082730/job/92405040982

Trivy flagged 9 distinct vulnerabilities (33 findings across bundled jars) in `jackson-core`, `jackson-databind`, and the netty native transport libraries. These require a dependency version bump to fix properly, so they are added to `.trivyignore` to unblock the release pipeline in the interim.

## Vulnerabilities added

**jackson-core / jackson-databind** (needs upgrade to 2.18.8+/2.21.4+):
- `GHSA-r7wm-3cxj-wff9` — jackson-core: Async parser maxNumberLength bypass
- `CVE-2026-54512` — jackson-databind: Arbitrary code execution via PolymorphicTypeValidator bypass
- `CVE-2026-54513` — jackson-databind: Security bypass allows arbitrary code execution
- `CVE-2026-54514` — jackson-databind: Information disclosure via eager DNS resolution
- `CVE-2026-54515` — jackson-databind: Ignored properties can be unexpectedly modified
- `CVE-2026-59888` — jackson-databind: `@JsonIgnore` bypass in Java Records
- `CVE-2026-59889` — jackson-databind: `@JsonView` bypassed for `@JsonUnwrapped` container properties
- `GHSA-mhm7-754m-9p8w` — jackson-databind: `@JsonView` bypass for creator properties

**netty** (needs upgrade to 4.1.135.Final/4.2.15.Final+):
- `CVE-2026-45536` — netty-transport-native-epoll/kqueue: DoS via file descriptor leak

All IDs were cross-checked against the NVD API and GitHub Advisory API to confirm they match the scan output.

## Notes
- These are added under a "Need to be fixed" style comment, not "False positive" — the actual dependency versions should be bumped in a follow-up.