### PR TITLE
Move the Zip BBEs to the third column of the common libraries

### DIFF
--- a/examples/index.json
+++ b/examples/index.json
@@ -5407,7 +5407,7 @@
   },
   {
     "title": "Zip",
-    "column": 3,
+    "column": 2,
     "category": "Common libraries",
     "samples": [
       {


### PR DESCRIPTION
### Purpose

The Zip BBEs added in #6425 show up in the fourth column of the common libraries on the BBE page instead of the third.

The `column` field in `examples/index.json` is zero-based, so the group needs `"column": 2` to land in the third column.

### Result

| col 1 | col 2 | col 3 | col 4 |
|---|---|---|---|
| Avro, IO, Messaging, Security, URL | Time, Cache, Log, EDI, OS | File, Random, Task, UUID, **Zip** | XSLT, XML data, YAML data, CSV data, XLSX data, Constraint |

Zip already followed UUID in the array, so no reordering was needed.