### PR TITLE
[2201.13.x] Update the zip BBE output for the reworded limit message

### DIFF
--- a/examples/zip-decompress-untrusted/zip_decompress_untrusted.out
+++ b/examples/zip-decompress-untrusted/zip_decompress_untrusted.out
@@ -1,2 +1,2 @@
 $ bal run zip_decompress_untrusted.bal
-Refused: the archive holds more than the 2 entries allowed
+Refused: cannot extract the archive: it contains more than the 2 entries allowed


### PR DESCRIPTION
## Purpose

`ballerina/zip` reworded its error messages so that each one names the operation that failed before its cause — see ballerina-platform/module-ballerina-zip#11. The untrusted-archive BBE prints one of them, so its recorded output moves with it:

```diff
-Refused: the archive holds more than the 2 entries allowed
+Refused: cannot extract the archive: it contains more than the 2 entries allowed
```

Only `zip_decompress_untrusted.out` changes; the sample itself is untouched.

## Note for the reviewer

- **Merge after the zip release carrying the new message.** Until then the example prints the old line and this file disagrees with it.
- The example's own `"Refused: "` prefix now sits in front of a message that already says what failed, so the line carries two colons. Say the word and I will drop the prefix from the sample in this PR.