### PR TITLE
Fix init example error message

### DIFF
--- a/examples/init-function/init_function.bal
+++ b/examples/init-function/init_function.bal
@@ -14,7 +14,7 @@ function init() returns error? {
     
     if value > 3 {
         // The initialization will fail with this error message.
-        return error("Value should less than 3");
+        return error("Value should be less than  or equal 3");
     }
 }
 

--- a/examples/init-function/init_function.bal
+++ b/examples/init-function/init_function.bal
@@ -14,7 +14,7 @@ function init() returns error? {
     
     if value > 3 {
         // The initialization will fail with this error message.
-        return error("Value should be less than  or equal 3");
+        return error("Value should be less than or equal 3");
     }
 }
 


### PR DESCRIPTION
## Purpose
The condition checks whether value > 3, which means valid values are less than or equal to 3. However, the current error message states Value should less than 3.

## Goals
Update the error message so that it accurately reflects the condition and is grammatically correct.

## Approach
Changed the error message from:

return error("Value should less than 3");

to:

return error("Value should be less than or equal to 3");


## User stories


## Release note


## Documentation
https://ballerina.io/learn/by-example/init-function/

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the `init` function example error message to accurately state that values must be less than or equal to 3. Removed extra whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->